### PR TITLE
Fix missing brace in metadata store removal test

### DIFF
--- a/BDI C++/Test/test_metadata_store.cpp
+++ b/BDI C++/Test/test_metadata_store.cpp
@@ -49,5 +49,6 @@ const MetadataVariant* v2 = store.getMetadata(h2);
      MetadataHandle h1 = store.addMetadata(SemanticTag{"Test:1", "Data"});
      EXPECT_NE(store.getMetadata(h1), nullptr);
      EXPECT_TRUE(store.removeMetadata(h1));
-     EXPECT_EQ(store.getMetadata(h1), nullptr);
-     EXPECT_FALSE(store.removeMetadata(h1)); // Remove again fails
+    EXPECT_EQ(store.getMetadata(h1), nullptr);
+    EXPECT_FALSE(store.removeMetadata(h1)); // Remove again fails
+}


### PR DESCRIPTION
## Summary
- close `MetadataStoreTest.Remove` by adding the missing closing brace
- ensure the test file ends with a newline

## Testing
- `g++ -std=c++17 'BDI C++/Test/test_metadata_store.cpp' -I'BDI C++' -lgtest -pthread -o /tmp/test_metadata_store` *(fails: bdi/meta/MetadataStore.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688d6f926fd483319d4d1abd75fa73b6