### PR TITLE
Phase 6 Bug Fixes: Fix opt_memcpy and opt_memset return values

### DIFF
--- a/bdi_kernel/docs/PHASE6_BUG_FIXES.md
+++ b/bdi_kernel/docs/PHASE6_BUG_FIXES.md
@@ -1,0 +1,343 @@
+# Phase 6 Bug Fixes - Critical Return Value Issues
+
+**Date:** October 3, 2025  
+**Phase:** Phase 6 - Build System & Compiler Optimization  
+**Branch:** phase6-build-optimization  
+**PR:** #44
+
+## Executive Summary
+
+Two critical bugs were identified and fixed in the SIMD-optimized memory operation functions (`opt_memcpy` and `opt_memset`) in `bdi_kernel/kernel/optimization.h`. Both functions violated the standard C library API contracts by returning modified pointers instead of the original destination pointers, which could cause serious issues in code that depends on these return values.
+
+---
+
+## Bug #1: Return Modified Pointer in opt_memcpy
+
+### Location
+- **File:** `bdi_kernel/kernel/optimization.h`
+- **Function:** `opt_memcpy` (lines 141-199)
+- **Severity:** Critical
+
+### Root Cause Analysis
+
+The `opt_memcpy` function implements high-performance memory copying using SIMD instructions (AVX-512, AVX2, or SSE2). The implementation processes data in aligned chunks for optimal performance:
+
+1. The function casts the destination pointer to SIMD vector types (`__m512i*`, `__m256i*`, or `__m128i*`)
+2. After processing aligned chunks, it advances the pointer: `dst = (void*)(&d[chunks])`
+3. The function then returns this **modified** `dst` pointer
+
+**The Problem:** The standard `memcpy` API contract requires returning the **original** destination pointer, not a pointer to the end of the copied region. This is documented in the C standard (ISO/IEC 9899):
+
+```c
+void *memcpy(void *restrict s1, const void *restrict s2, size_t n);
+```
+
+> Returns: The value of s1 (the original destination pointer)
+
+### Impact on API Contracts
+
+Code that chains the return value will misbehave:
+
+```c
+// Expected behavior: buf points to start of copied data
+char *buf = opt_memcpy(buffer, source, 1024);
+
+// Actual behavior: buf points to buffer + 1024 (end of copied region)
+// Any subsequent operations on buf will access wrong memory!
+```
+
+Real-world failure scenarios:
+- **Chained operations:** `process_data(opt_memcpy(buf, src, n))` passes wrong pointer
+- **Pointer arithmetic:** `opt_memcpy(buf, src, n) + offset` calculates from wrong base
+- **Return value checks:** Code checking if return equals destination will fail
+- **Buffer management:** Systems tracking buffer pointers will lose track of allocations
+
+### Solution Implemented
+
+Added preservation of the original destination pointer:
+
+```c
+void* opt_memcpy(void* RESTRICT dst, const void* RESTRICT src, size_t n) {
+    void *orig_dst = dst;  /* Preserve original pointer for return */
+    
+    // ... SIMD optimization code that modifies dst ...
+    
+    return orig_dst;  /* Return original pointer, not modified one */
+}
+```
+
+**Key changes:**
+1. Line 142: Added `void *orig_dst = dst;` at function entry
+2. Line 198: Changed `return dst;` to `return orig_dst;`
+3. All code paths now return the original pointer
+
+---
+
+## Bug #2: Return Modified Pointer in opt_memset
+
+### Location
+- **File:** `bdi_kernel/kernel/optimization.h`
+- **Function:** `opt_memset` (lines 204-257)
+- **Severity:** Critical
+
+### Root Cause Analysis
+
+The `opt_memset` function has an identical issue to `opt_memcpy`. It uses SIMD instructions to efficiently fill memory with a byte pattern:
+
+1. Creates a SIMD pattern vector with the fill value
+2. Processes memory in aligned chunks
+3. Advances the destination pointer: `dst = (void*)(&d[chunks])`
+4. Returns the **modified** pointer instead of the original
+
+**The Problem:** The standard `memset` API contract also requires returning the original destination pointer:
+
+```c
+void *memset(void *s, int c, size_t n);
+```
+
+> Returns: The value of s (the original destination pointer)
+
+### Impact on API Contracts
+
+Similar failure scenarios as `opt_memcpy`:
+
+```c
+// Expected: ptr points to start of zeroed buffer
+void *ptr = opt_memset(buffer, 0, 4096);
+
+// Actual: ptr points to buffer + 4096 (end of region)
+// Subsequent use of ptr accesses uninitialized memory!
+```
+
+Critical use cases affected:
+- **Initialization chains:** `initialize(opt_memset(buf, 0, size))` passes wrong pointer
+- **Zero-and-use patterns:** `use_buffer(opt_memset(alloc(), 0, n))` fails
+- **Conditional initialization:** `if (opt_memset(buf, 0, n) == buf)` always false
+- **Memory pool management:** Pool systems lose track of buffer starts
+
+### Solution Implemented
+
+Applied the same fix as `opt_memcpy`:
+
+```c
+void* opt_memset(void* dst, int c, size_t n) {
+    void *orig_dst = dst;  /* Preserve original pointer for return */
+    uint8_t val = (uint8_t)c;
+    
+    // ... SIMD optimization code that modifies dst ...
+    
+    return orig_dst;  /* Return original pointer, not modified one */
+}
+```
+
+**Key changes:**
+1. Line 206: Added `void *orig_dst = dst;` at function entry
+2. Line 256: Changed `return dst;` to `return orig_dst;`
+3. All code paths now return the original pointer
+
+---
+
+## Performance Impact
+
+**Good news:** These fixes have **ZERO performance impact** on the optimized code paths.
+
+- The `orig_dst` variable is stored in a register at function entry
+- No additional memory operations are required
+- SIMD optimization paths remain unchanged
+- The compiler can optimize away the extra variable in many cases
+- Return value is simply loaded from a different register
+
+The fixes only affect the return statement, not the actual memory operation logic.
+
+---
+
+## Testing Recommendations
+
+### 1. Unit Tests
+
+Create comprehensive unit tests for both functions:
+
+```c
+void test_opt_memcpy_return_value(void) {
+    char src[1024], dst[1024];
+    void *result = opt_memcpy(dst, src, 1024);
+    assert(result == (void*)dst);  // Must return original pointer
+    
+    // Test with various sizes and alignments
+    for (size_t size = 1; size <= 1024; size++) {
+        result = opt_memcpy(dst, src, size);
+        assert(result == (void*)dst);
+    }
+}
+
+void test_opt_memset_return_value(void) {
+    char buffer[1024];
+    void *result = opt_memset(buffer, 0xAA, 1024);
+    assert(result == (void*)buffer);  // Must return original pointer
+    
+    // Test with various sizes and alignments
+    for (size_t size = 1; size <= 1024; size++) {
+        result = opt_memset(buffer, 0, size);
+        assert(result == (void*)buffer);
+    }
+}
+```
+
+### 2. Integration Tests
+
+Test real-world usage patterns:
+
+```c
+// Test chained operations
+void test_chained_operations(void) {
+    char src[100], dst[100];
+    char *ptr = (char*)opt_memcpy(dst, src, 50);
+    ptr[0] = 'X';  // Should modify dst[0], not dst[50]
+    assert(dst[0] == 'X');
+}
+
+// Test return value in conditionals
+void test_conditional_usage(void) {
+    char buffer[100];
+    if (opt_memset(buffer, 0, 100) != buffer) {
+        assert(0);  // Should never happen
+    }
+}
+```
+
+### 3. Alignment Tests
+
+Verify all SIMD paths return correct pointers:
+
+```c
+void test_simd_paths(void) {
+    // Test AVX-512 path (64-byte aligned, >= 64 bytes)
+    char *aligned64 = aligned_alloc(64, 1024);
+    assert(opt_memcpy(aligned64, src, 1024) == aligned64);
+    
+    // Test AVX2 path (32-byte aligned, >= 32 bytes)
+    char *aligned32 = aligned_alloc(32, 512);
+    assert(opt_memcpy(aligned32, src, 512) == aligned32);
+    
+    // Test SSE2 path (16-byte aligned, >= 16 bytes)
+    char *aligned16 = aligned_alloc(16, 256);
+    assert(opt_memcpy(aligned16, src, 256) == aligned16);
+    
+    // Test fallback path (unaligned or small)
+    char unaligned[100];
+    assert(opt_memcpy(unaligned, src, 10) == unaligned);
+}
+```
+
+### 4. Regression Tests
+
+Ensure the fixes don't break existing functionality:
+
+```c
+void test_correctness(void) {
+    char src[1024], dst[1024];
+    
+    // Fill source with pattern
+    for (int i = 0; i < 1024; i++) {
+        src[i] = (char)i;
+    }
+    
+    // Test opt_memcpy correctness
+    opt_memcpy(dst, src, 1024);
+    assert(memcmp(dst, src, 1024) == 0);
+    
+    // Test opt_memset correctness
+    opt_memset(dst, 0xAA, 1024);
+    for (int i = 0; i < 1024; i++) {
+        assert(dst[i] == (char)0xAA);
+    }
+}
+```
+
+### 5. Performance Benchmarks
+
+Verify no performance regression:
+
+```c
+void benchmark_memcpy(void) {
+    char src[1MB], dst[1MB];
+    uint64_t start = opt_rdtsc();
+    
+    for (int i = 0; i < 10000; i++) {
+        opt_memcpy(dst, src, 1MB);
+    }
+    
+    uint64_t end = opt_rdtsc();
+    printf("opt_memcpy: %lu cycles\n", (end - start) / 10000);
+}
+```
+
+---
+
+## Verification Steps
+
+To verify the fixes are working correctly:
+
+1. **Compile test:** Ensure the modified header compiles without errors
+   ```bash
+   gcc -I. -O2 -msse2 -mavx2 -c test_optimization.c
+   ```
+
+2. **Static analysis:** Run static analyzers to verify pointer handling
+   ```bash
+   clang-tidy bdi_kernel/kernel/optimization.h
+   ```
+
+3. **Runtime tests:** Execute the unit tests above with various compiler flags
+   ```bash
+   gcc -O0 test.c && ./a.out  # No optimization
+   gcc -O2 test.c && ./a.out  # Standard optimization
+   gcc -O3 test.c && ./a.out  # Aggressive optimization
+   ```
+
+4. **Address sanitizer:** Check for any memory issues
+   ```bash
+   gcc -fsanitize=address test.c && ./a.out
+   ```
+
+---
+
+## Lessons Learned
+
+### 1. API Contract Compliance
+When implementing optimized replacements for standard library functions, **always** maintain exact API compatibility, including return values. Even if the return value seems unused, code may depend on it.
+
+### 2. Code Review Focus
+Pay special attention to:
+- Pointer modifications in optimized code paths
+- Return statements in functions with multiple code paths
+- Compliance with standard library semantics
+
+### 3. Testing Strategy
+- Test return values explicitly, not just functional correctness
+- Include tests for all optimization paths (SIMD and fallback)
+- Verify behavior with different alignments and sizes
+
+### 4. Documentation
+Clearly document any deviations from standard APIs, even if intentional. In this case, the deviation was unintentional and caused bugs.
+
+---
+
+## Related Issues
+
+- **PR #44:** Phase 6 - Build System & Compiler Optimization
+- **Branch:** phase6-build-optimization
+
+---
+
+## Conclusion
+
+Both bugs have been fixed with minimal code changes that maintain full performance while ensuring correct API semantics. The fixes are backward compatible and require no changes to calling code. All existing optimizations remain active and effective.
+
+**Status:** ✅ Fixed and ready for testing
+
+**Next Steps:**
+1. Review and merge this fix into PR #44
+2. Add comprehensive unit tests for return value correctness
+3. Run full regression test suite
+4. Update any documentation that references these functions

--- a/bdi_kernel/kernel/optimization.h
+++ b/bdi_kernel/kernel/optimization.h
@@ -139,6 +139,8 @@
  */
 ALWAYS_INLINE HOT_CODE
 void* opt_memcpy(void* RESTRICT dst, const void* RESTRICT src, size_t n) {
+    void *orig_dst = dst;  /* Preserve original pointer for return */
+    
 #if defined(HAS_AVX512F)
     /* AVX-512 path: 64 bytes per iteration */
     if (n >= 64 && ((uintptr_t)dst & 63) == 0 && ((uintptr_t)src & 63) == 0) {
@@ -193,7 +195,7 @@ void* opt_memcpy(void* RESTRICT dst, const void* RESTRICT src, size_t n) {
         d8[i] = s8[i];
     }
     
-    return dst;
+    return orig_dst;  /* Return original pointer, not modified one */
 }
 
 /**
@@ -201,6 +203,7 @@ void* opt_memcpy(void* RESTRICT dst, const void* RESTRICT src, size_t n) {
  */
 ALWAYS_INLINE HOT_CODE
 void* opt_memset(void* dst, int c, size_t n) {
+    void *orig_dst = dst;  /* Preserve original pointer for return */
     uint8_t val = (uint8_t)c;
     
 #if defined(HAS_AVX512F)
@@ -250,7 +253,7 @@ void* opt_memset(void* dst, int c, size_t n) {
         d8[i] = val;
     }
     
-    return dst;
+    return orig_dst;  /* Return original pointer, not modified one */
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Phase 6 Bug Fixes: Critical Memory Function Return Value Corrections

This PR addresses two critical bugs discovered in the Phase 6 Build System & Compiler Optimization implementation that could cause undefined behavior and memory corruption in code relying on standard memory function semantics.

### Bugs Fixed

#### Bug #1: opt_memcpy Return Value Issue
**Problem:** The `opt_memcpy` function was returning a modified destination pointer instead of the original destination pointer, violating the standard `memcpy` contract.

**Impact:** Any code that relies on the return value of `memcpy` (e.g., chaining operations like `memcpy(dst, src, n) + offset`) would receive an incorrect pointer, potentially leading to:
- Memory corruption
- Segmentation faults
- Undefined behavior in pointer arithmetic

**Fix:** Preserved the original destination pointer in `orig_dst` variable and return it instead of the modified pointer.

#### Bug #2: opt_memset Return Value Issue
**Problem:** The `opt_memset` function was returning a modified destination pointer instead of the original destination pointer, violating the standard `memset` contract.

**Impact:** Similar to Bug #1, any code relying on the return value would receive an incorrect pointer, causing:
- Memory corruption
- Incorrect pointer arithmetic
- Potential crashes in chained operations

**Fix:** Preserved the original destination pointer in `orig_dst` variable and return it instead of the modified pointer.

### Files Changed
- `bdi_kernel/kernel/optimization.h` - Fixed both `opt_memcpy` and `opt_memset` functions
- `bdi_kernel/docs/PHASE6_BUG_FIXES.md` - Comprehensive documentation of the bugs and fixes

### Technical Details
Both functions now follow this pattern:
```c
void *orig_dst = dst;  /* Preserve original pointer for return */
// ... SIMD optimized operations that modify dst ...
return orig_dst;  /* Return original pointer, not modified one */
```

This ensures compliance with the C standard library semantics where `memcpy` and `memset` return the original destination pointer, allowing for safe pointer arithmetic and function chaining.

### Testing Recommendations
- Verify all code using `opt_memcpy` and `opt_memset` return values
- Test pointer arithmetic operations on returned values
- Validate chained memory operations

### Documentation
Full details available in `bdi_kernel/docs/PHASE6_BUG_FIXES.md`

---
**Priority:** High - These bugs affect core memory operations and could cause system instability.