### PR TITLE
Fix COW Memory Region List Corruption (Bug #3 in PR #52)

### DIFF
--- a/bdi_kernel/docs/PR51_BUG_FIXES.md
+++ b/bdi_kernel/docs/PR51_BUG_FIXES.md
@@ -1,8 +1,9 @@
+
 # PR #51 Bug Fixes - Process Management Critical Issues
 
 ## Overview
 
-This document describes two critical P0 bugs found in PR #51 (Phase 8: Process Management & Lifecycle) and their fixes. Both bugs were identified by automated code review and would have caused runtime failures.
+This document describes critical bugs found in PR #51 (Phase 8: Process Management & Lifecycle) and their fixes. The bugs were identified by automated code review and would have caused runtime failures.
 
 **PR #51 Status**: Merged on 2025-10-03 at 09:52:33 UTC  
 **Fix Branch**: `pr51-bugfix-process-table`  
@@ -145,7 +146,7 @@ atomic_fetch_add(&parent_region->ref_count, 1);  // Parent's counter
 - Potential security vulnerability
 - Crashes when processes with COW memory exit
 
-### Solution
+### Solution (PR #52 - First Attempt)
 
 Modified COW implementation to share the same `MemoryRegion` objects between parent and child:
 
@@ -203,6 +204,311 @@ static int copy_memory_regions_cow(ProcessControlBlock *parent,
 
 ---
 
+## Bug #3: COW Memory Region List Corruption (New Bug in PR #52)
+
+### Problem Description
+
+**Location**: `bdi_kernel/process/process_lifecycle.c:43-70` (PR #52 fix)
+
+The PR #52 fix introduced a new critical bug by making both parent and child share the same `MemoryRegion` linked list nodes:
+
+```c
+/* Link the shared region into child's region list */
+if (prev_child_region == nullptr) {
+    child->memory_regions = parent_region;  // Both point to same node!
+} else {
+    prev_child_region->next = parent_region;  // Shared next pointers!
+}
+```
+
+**Root Cause**:
+1. Both parent and child now share the same linked list nodes
+2. The `next` pointers are part of the shared structure
+3. Other code (like `process_destroy_shm`) assumes each process owns its own descriptor
+4. When the parent removes a region:
+   - It unlinks the node from its list
+   - Frees the node unconditionally
+   - The child still references the freed node → **dangling pointer and use-after-free**
+5. The linked list structure should be process-specific, but the actual memory region data and refcount should be shared
+
+**Impact**:
+- List corruption when one process modifies its memory region list
+- Use-after-free when one process frees a descriptor the other still references
+- Dangling pointers in process memory region lists
+- Crashes when processes independently manage their memory regions
+- Violates the principle that each process should have independent list management
+
+### Solution (Current Fix)
+
+Implement two-level refcounting with separate descriptors but shared physical memory tracking:
+
+**1. Updated `MemoryRegion` structure in `process.h`**:
+```c
+/**
+ * @brief Memory region descriptor
+ * 
+ * Two-level refcounting for COW support:
+ * - ref_count: Tracks lifetime of this descriptor (process-local)
+ * - cow_ref_count: Tracks shared physical memory (shared between processes)
+ * 
+ * For non-COW regions, cow_ref_count is nullptr.
+ * For COW regions, multiple descriptors share the same cow_ref_count pointer.
+ */
+typedef struct MemoryRegion {
+    void *base;                         /* Base address */
+    size_t size;                        /* Region size */
+    uint32_t flags;                     /* Memory flags */
+    _Atomic uint32_t ref_count;         /* Descriptor reference count */
+    _Atomic(int) *cow_ref_count;        /* Shared COW refcount (nullptr if not COW) */
+    struct MemoryRegion *next;          /* Next region in list */
+} MemoryRegion;
+```
+
+**2. Updated `copy_memory_regions_cow()` in `process_lifecycle.c`**:
+```c
+/**
+ * @brief Copy memory regions with COW support
+ * 
+ * Two-level refcounting approach:
+ * - Each process gets its own MemoryRegion descriptor (for list management)
+ * - COW regions share a cow_ref_count pointer (for physical memory lifetime)
+ * 
+ * This allows:
+ * - Process-local list management (each process can add/remove regions independently)
+ * - Correct shared memory lifetime tracking (physical memory freed only when all processes done)
+ */
+static int copy_memory_regions_cow(ProcessControlBlock *parent,
+                                   ProcessControlBlock *child) {
+    if (parent == nullptr || child == nullptr) {
+        return -EINVAL;
+    }
+    
+    MemoryRegion *parent_region = parent->memory_regions;
+    MemoryRegion *prev_child_region = nullptr;
+    
+    while (parent_region != nullptr) {
+        /* Allocate NEW descriptor for child (own list node) */
+        MemoryRegion *child_region = ALLOC(MemoryRegion);
+        if (child_region == nullptr) {
+            fprintf(stderr, "PROCESS: Failed to allocate memory region\n");
+            return -ENOMEM;
+        }
+        
+        /* Copy region metadata */
+        child_region->base = parent_region->base;
+        child_region->size = parent_region->size;
+        child_region->flags = parent_region->flags | MEM_FLAG_COW;
+        child_region->next = nullptr;
+        
+        /* Allocate shared refcount if not already allocated */
+        if (parent_region->cow_ref_count == nullptr) {
+            /* First fork - allocate shared refcount */
+            _Atomic(int) *shared_ref = ALLOC(_Atomic(int));
+            if (shared_ref == nullptr) {
+                FREE(child_region, MemoryRegion);
+                fprintf(stderr, "PROCESS: Failed to allocate shared refcount\n");
+                return -ENOMEM;
+            }
+            atomic_init(shared_ref, 2);  /* Parent + child */
+            parent_region->cow_ref_count = shared_ref;
+            child_region->cow_ref_count = shared_ref;
+        } else {
+            /* Already COW - increment existing shared refcount */
+            atomic_fetch_add(parent_region->cow_ref_count, 1);
+            child_region->cow_ref_count = parent_region->cow_ref_count;
+        }
+        
+        /* Initialize child's own refcount to 1 (for descriptor lifetime) */
+        atomic_init(&child_region->ref_count, 1);
+        
+        /* Link into child's region list */
+        if (prev_child_region == nullptr) {
+            child->memory_regions = child_region;
+        } else {
+            prev_child_region->next = child_region;
+        }
+        
+        prev_child_region = child_region;
+        parent_region = parent_region->next;
+    }
+    
+    return 0;
+}
+```
+
+**3. Added `free_memory_region()` helper function**:
+```c
+/**
+ * @brief Free a memory region with proper COW refcount handling
+ * 
+ * @param region Memory region to free
+ */
+static void free_memory_region(MemoryRegion *region) {
+    if (region == nullptr) {
+        return;
+    }
+    
+    /* Decrement shared refcount if COW */
+    if (region->cow_ref_count != nullptr) {
+        int old_count = atomic_fetch_sub(region->cow_ref_count, 1);
+        if (old_count == 1) {
+            /* Last reference - free the shared refcount and physical memory */
+            FREE(region->cow_ref_count, _Atomic(int));
+            free_memory(region->base, region->size);
+            printf("PROCESS: Freed COW physical memory at %p (last reference)\n", 
+                   region->base);
+        } else {
+            printf("PROCESS: Decremented COW refcount for %p (remaining: %d)\n",
+                   region->base, old_count - 1);
+        }
+    } else {
+        /* Not COW - free physical memory directly */
+        free_memory(region->base, region->size);
+        printf("PROCESS: Freed non-COW physical memory at %p\n", region->base);
+    }
+    
+    /* Always free the descriptor itself */
+    FREE(region, MemoryRegion);
+}
+```
+
+**4. Updated `process_exit()` to use the new helper**:
+```c
+/* Free memory regions with proper COW handling */
+MemoryRegion *region = pcb->memory_regions;
+while (region != nullptr) {
+    MemoryRegion *next = region->next;
+    free_memory_region(region);
+    region = next;
+}
+pcb->memory_regions = nullptr;
+```
+
+**5. Updated `process_destroy_shm()` in `process_ipc.c`**:
+```c
+int process_destroy_shm(ProcessControlBlock *pcb, void *shm_ptr) {
+    if (pcb == nullptr || shm_ptr == nullptr) {
+        fprintf(stderr, "PROCESS_IPC: Invalid parameters for destroy_shm\n");
+        return -EINVAL;
+    }
+    
+    printf("PROCESS_IPC: Destroying shared memory at %p for process %llu\n",
+           shm_ptr,
+           (unsigned long long)pcb->pid);
+    
+    /* Find memory region */
+    MemoryRegion *region = pcb->memory_regions;
+    MemoryRegion *prev = nullptr;
+    
+    while (region != nullptr) {
+        if (region->base == shm_ptr) {
+            /* Remove from list first */
+            if (prev == nullptr) {
+                pcb->memory_regions = region->next;
+            } else {
+                prev->next = region->next;
+            }
+            
+            /* Decrement shared refcount if COW */
+            if (region->cow_ref_count != nullptr) {
+                int old_count = atomic_fetch_sub(region->cow_ref_count, 1);
+                if (old_count == 1) {
+                    /* Last reference - free the shared refcount and physical memory */
+                    FREE(region->cow_ref_count, _Atomic(int));
+                    free_memory(region->base, region->size);
+                    printf("PROCESS_IPC: Shared memory freed (last reference)\n");
+                } else {
+                    printf("PROCESS_IPC: Decremented shared refcount (remaining: %d)\n",
+                           old_count - 1);
+                }
+            } else {
+                /* Not COW - free physical memory directly */
+                free_memory(region->base, region->size);
+                printf("PROCESS_IPC: Non-COW memory freed\n");
+            }
+            
+            /* Free the descriptor */
+            FREE(region, MemoryRegion);
+            return 0;
+        }
+        
+        prev = region;
+        region = region->next;
+    }
+    
+    fprintf(stderr, "PROCESS_IPC: Shared memory region not found\n");
+    return -ENOENT;
+}
+```
+
+**6. Updated `process_create_shm()` to use shared refcount**:
+```c
+void *process_create_shm(ProcessControlBlock *pcb1,
+                         ProcessControlBlock *pcb2,
+                         size_t size,
+                         uint32_t flags) {
+    // ... allocation code ...
+    
+    /* Allocate shared COW refcount */
+    _Atomic(int) *shared_ref = ALLOC(_Atomic(int));
+    if (shared_ref == nullptr) {
+        fprintf(stderr, "PROCESS_IPC: Failed to allocate shared refcount\n");
+        free_memory(shm_ptr, size);
+        return nullptr;
+    }
+    atomic_init(shared_ref, 2);  /* Shared by 2 processes */
+    
+    /* Initialize region descriptors with shared COW refcount */
+    region1->base = shm_ptr;
+    region1->size = size;
+    region1->flags = flags;
+    atomic_init(&region1->ref_count, 1);  /* Descriptor refcount */
+    region1->cow_ref_count = shared_ref;  /* Shared physical memory refcount */
+    region1->next = pcb1->memory_regions;
+    
+    region2->base = shm_ptr;
+    region2->size = size;
+    region2->flags = flags;
+    atomic_init(&region2->ref_count, 1);  /* Descriptor refcount */
+    region2->cow_ref_count = shared_ref;  /* Shared physical memory refcount */
+    region2->next = pcb2->memory_regions;
+    
+    // ... rest of function ...
+}
+```
+
+**Key Design Principles**:
+
+1. **Two-Level Refcounting**:
+   - `ref_count`: Tracks the lifetime of the descriptor itself (process-local)
+   - `cow_ref_count`: Tracks the lifetime of the shared physical memory (shared pointer)
+
+2. **Separate Descriptors**:
+   - Each process gets its own `MemoryRegion` descriptor
+   - Each descriptor has its own `next` pointer for list management
+   - Processes can independently add/remove regions from their lists
+
+3. **Shared Physical Memory Tracking**:
+   - COW regions share a `cow_ref_count` pointer
+   - Physical memory is freed only when the last process releases it
+   - The shared refcount itself is freed when the last reference is dropped
+
+4. **Non-COW Compatibility**:
+   - For non-COW regions, `cow_ref_count` is `nullptr`
+   - Physical memory is freed immediately when the descriptor is freed
+   - No overhead for non-shared memory
+
+**Benefits**:
+- Process-local list management (no list corruption)
+- Correct shared memory lifetime tracking
+- No use-after-free or dangling pointers
+- Each process can independently manage its memory regions
+- Proper cleanup when processes exit in any order
+- Supports multiple forks (grandchildren, etc.)
+- Clean separation of concerns (descriptor vs. physical memory)
+
+---
+
 ## Testing Recommendations
 
 ### Bug #1 Testing
@@ -219,11 +525,22 @@ static int copy_memory_regions_cow(ProcessControlBlock *parent,
 5. **Memory leak test**: Verify memory is freed when last reference is dropped
 6. **Stress test**: Rapid fork-exit cycles to catch race conditions
 
+### Bug #3 Testing (New)
+1. **List independence test**: Fork process, have each process add/remove regions independently
+2. **Descriptor lifetime test**: Verify descriptors are freed when process exits
+3. **Physical memory lifetime test**: Verify physical memory is freed only when all processes exit
+4. **Multiple fork test**: Fork multiple times, verify refcount increments correctly
+5. **Grandchild test**: Fork chains (parent → child → grandchild), verify all work correctly
+6. **Shared memory test**: Create shared memory between processes, verify proper cleanup
+7. **Mixed COW/non-COW test**: Verify both COW and non-COW regions work correctly
+8. **Race condition test**: Concurrent fork and exit operations
+
 ### Integration Testing
 1. **Multi-process**: Create multiple child processes
 2. **Deep fork**: Fork chains (grandchildren)
 3. **Concurrent**: Multiple processes forking simultaneously
 4. **Memory pressure**: Fork under low memory conditions
+5. **List manipulation**: Processes adding/removing regions while others fork/exit
 
 ---
 
@@ -237,15 +554,39 @@ static int copy_memory_regions_cow(ProcessControlBlock *parent,
 ### 2. `bdi_kernel/process/process.h`
 - Added `process_insert()` declaration (lines 323-329)
 - Marked with `[[nodiscard]]` for safety
+- **Updated `MemoryRegion` structure** (lines 118-140):
+  - Added `cow_ref_count` field for shared physical memory tracking
+  - Added comprehensive documentation explaining two-level refcounting
 
 ### 3. `bdi_kernel/process/process_lifecycle.c`
 - Fixed `process_fork()` to use `process_insert()` (lines 244-250)
 - Removed incorrect extern declaration
-- Fixed `copy_memory_regions_cow()` to share regions (lines 35-70)
-- Added comprehensive documentation
+- **Completely rewrote `copy_memory_regions_cow()`** (lines 35-105):
+  - Allocates separate descriptors for each process
+  - Implements shared `cow_ref_count` pointer
+  - Handles first fork and subsequent forks correctly
+- **Added `free_memory_region()` helper** (lines 107-133):
+  - Properly handles COW refcount decrement
+  - Frees physical memory only when last reference is dropped
+  - Frees shared refcount when last reference is dropped
+- **Updated `process_exit()`** (lines 400-472):
+  - Uses `free_memory_region()` for proper cleanup
+  - Iterates through all memory regions
 
-### 4. `bdi_kernel/docs/PR51_BUG_FIXES.md` (this file)
-- Complete documentation of bugs and fixes
+### 4. `bdi_kernel/process/process_ipc.c`
+- **Updated `process_create_shm()`** (lines 176-229):
+  - Allocates shared `cow_ref_count` for new shared memory
+  - Creates separate descriptors for each process
+  - Both descriptors point to the same shared refcount
+- **Updated `process_destroy_shm()`** (lines 234-276):
+  - Properly handles COW refcount decrement
+  - Frees physical memory only when last reference is dropped
+  - Frees descriptor after unlinking from list
+
+### 5. `bdi_kernel/docs/PR51_BUG_FIXES.md` (this file)
+- Complete documentation of all three bugs and fixes
+- Added Bug #3 section with detailed explanation
+- Updated testing recommendations
 
 ---
 
@@ -256,6 +597,7 @@ All files compile successfully with GCC C11:
 ```bash
 gcc -c -std=c11 -I. bdi_kernel/process/process_manager.c
 gcc -c -std=c11 -I. bdi_kernel/process/process_lifecycle.c
+gcc -c -std=c11 -I. bdi_kernel/process/process_ipc.c
 ```
 
 **Warnings**: Only minor warnings about unused return values (pre-existing, not related to fixes)
@@ -264,26 +606,28 @@ gcc -c -std=c11 -I. bdi_kernel/process/process_lifecycle.c
 
 ## Conclusion
 
-Both bugs were critical P0 issues that would have prevented the code from working:
+Three critical P0 issues have been identified and fixed:
 
-1. **Bug #1** would have caused link-time failures, making the code unusable
-2. **Bug #2** would have caused use-after-free and double-free, leading to crashes and potential security vulnerabilities
+1. **Bug #1** (Original): Process table linkage error - would have caused link-time failures
+2. **Bug #2** (Original): COW use-after-free - would have caused crashes and security vulnerabilities
+3. **Bug #3** (New in PR #52): COW list corruption - would have caused dangling pointers and use-after-free
 
-The fixes:
-- Follow existing code patterns and conventions
-- Maintain proper encapsulation
-- Ensure memory safety
-- Add comprehensive error handling
-- Include detailed documentation
+The final solution implements a sophisticated two-level refcounting system that:
+- Maintains process-local list management (no list corruption)
+- Correctly tracks shared physical memory lifetime
+- Supports arbitrary fork chains and concurrent operations
+- Provides clean separation between descriptor and physical memory lifetimes
+- Works correctly for both COW and non-COW memory regions
 
-**Status**: ✅ All bugs fixed and tested  
-**Ready for**: New pull request and review
+**Status**: ✅ All bugs fixed and documented  
+**Ready for**: Testing and review
 
 ---
 
 ## References
 
 - Original PR: #51 - "Phase 8: Process Management & Lifecycle"
+- Fix PR: #52 - "Fix PR #51 critical bugs"
 - Review Comments: 2 P0 issues identified by chatgpt-codex-connector[bot]
 - Fix Branch: `pr51-bugfix-process-table`
 - Documentation: `PHASE8_PROCESS_MANAGEMENT.md`

--- a/bdi_kernel/process/process.h
+++ b/bdi_kernel/process/process.h
@@ -1,4 +1,5 @@
 
+
 /**
  * @file process.h
  * @brief Process Control Block (PCB) and Process Management
@@ -114,12 +115,20 @@ typedef struct {
 
 /**
  * @brief Memory region descriptor
+ * 
+ * Two-level refcounting for COW support:
+ * - ref_count: Tracks lifetime of this descriptor (process-local)
+ * - cow_ref_count: Tracks shared physical memory (shared between processes)
+ * 
+ * For non-COW regions, cow_ref_count is nullptr.
+ * For COW regions, multiple descriptors share the same cow_ref_count pointer.
  */
 typedef struct MemoryRegion {
     void *base;                         /* Base address */
     size_t size;                        /* Region size */
     uint32_t flags;                     /* Memory flags */
-    _Atomic uint32_t ref_count;         /* Reference count (for COW) */
+    _Atomic uint32_t ref_count;         /* Descriptor reference count */
+    _Atomic(int) *cow_ref_count;        /* Shared COW refcount (nullptr if not COW) */
     struct MemoryRegion *next;          /* Next region in list */
 } MemoryRegion;
 

--- a/bdi_kernel/process/process_ipc.c
+++ b/bdi_kernel/process/process_ipc.c
@@ -1,4 +1,5 @@
 
+
 /**
  * @file process_ipc.c
  * @brief Process IPC Integration
@@ -194,6 +195,15 @@ void *process_create_shm(ProcessControlBlock *pcb1,
         return nullptr;
     }
     
+    /* Allocate shared COW refcount */
+    _Atomic(int) *shared_ref = ALLOC(_Atomic(int));
+    if (shared_ref == nullptr) {
+        fprintf(stderr, "PROCESS_IPC: Failed to allocate shared refcount\n");
+        free_memory(shm_ptr, size);
+        return nullptr;
+    }
+    atomic_init(shared_ref, 2);  /* Shared by 2 processes */
+    
     /* Create memory region descriptors for both processes */
     MemoryRegion *region1 = ALLOC(MemoryRegion);
     MemoryRegion *region2 = ALLOC(MemoryRegion);
@@ -202,21 +212,24 @@ void *process_create_shm(ProcessControlBlock *pcb1,
         fprintf(stderr, "PROCESS_IPC: Failed to allocate memory regions\n");
         if (region1 != nullptr) FREE(region1, MemoryRegion);
         if (region2 != nullptr) FREE(region2, MemoryRegion);
+        FREE(shared_ref, _Atomic(int));
         free_memory(shm_ptr, size);
         return nullptr;
     }
     
-    /* Initialize region descriptors */
+    /* Initialize region descriptors with shared COW refcount */
     region1->base = shm_ptr;
     region1->size = size;
     region1->flags = flags;
-    atomic_init(&region1->ref_count, 2);  /* Shared by 2 processes */
+    atomic_init(&region1->ref_count, 1);  /* Descriptor refcount */
+    region1->cow_ref_count = shared_ref;  /* Shared physical memory refcount */
     region1->next = pcb1->memory_regions;
     
     region2->base = shm_ptr;
     region2->size = size;
     region2->flags = flags;
-    atomic_init(&region2->ref_count, 2);  /* Shared by 2 processes */
+    atomic_init(&region2->ref_count, 1);  /* Descriptor refcount */
+    region2->cow_ref_count = shared_ref;  /* Shared physical memory refcount */
     region2->next = pcb2->memory_regions;
     
     /* Add to process memory region lists */
@@ -247,22 +260,32 @@ int process_destroy_shm(ProcessControlBlock *pcb, void *shm_ptr) {
     
     while (region != nullptr) {
         if (region->base == shm_ptr) {
-            /* Decrement reference count */
-            uint32_t refs = atomic_fetch_sub(&region->ref_count, 1) - 1;
-            
-            if (refs == 0) {
-                /* Last reference, free the memory */
-                free_memory(region->base, region->size);
-                printf("PROCESS_IPC: Shared memory freed\n");
-            }
-            
-            /* Remove from list */
+            /* Remove from list first */
             if (prev == nullptr) {
                 pcb->memory_regions = region->next;
             } else {
                 prev->next = region->next;
             }
             
+            /* Decrement shared refcount if COW */
+            if (region->cow_ref_count != nullptr) {
+                int old_count = atomic_fetch_sub(region->cow_ref_count, 1);
+                if (old_count == 1) {
+                    /* Last reference - free the shared refcount and physical memory */
+                    FREE(region->cow_ref_count, _Atomic(int));
+                    free_memory(region->base, region->size);
+                    printf("PROCESS_IPC: Shared memory freed (last reference)\n");
+                } else {
+                    printf("PROCESS_IPC: Decremented shared refcount (remaining: %d)\n",
+                           old_count - 1);
+                }
+            } else {
+                /* Not COW - free physical memory directly */
+                free_memory(region->base, region->size);
+                printf("PROCESS_IPC: Non-COW memory freed\n");
+            }
+            
+            /* Free the descriptor */
             FREE(region, MemoryRegion);
             return 0;
         }

--- a/bdi_kernel/process/process_lifecycle.c
+++ b/bdi_kernel/process/process_lifecycle.c
@@ -1,4 +1,5 @@
 
+
 /**
  * @file process_lifecycle.c
  * @brief Process Lifecycle Management
@@ -35,10 +36,13 @@ extern uint32_t pcb_unref(ProcessControlBlock *pcb);
 /**
  * @brief Copy memory regions with COW support
  * 
- * For proper COW semantics, both parent and child must share the same
- * MemoryRegion objects (not copies) so they share the same atomic refcount.
- * This prevents use-after-free when one process exits while the other still
- * holds references to the shared memory.
+ * Two-level refcounting approach:
+ * - Each process gets its own MemoryRegion descriptor (for list management)
+ * - COW regions share a cow_ref_count pointer (for physical memory lifetime)
+ * 
+ * This allows:
+ * - Process-local list management (each process can add/remove regions independently)
+ * - Correct shared memory lifetime tracking (physical memory freed only when all processes done)
  */
 static int copy_memory_regions_cow(ProcessControlBlock *parent,
                                    ProcessControlBlock *child) {
@@ -46,27 +50,89 @@ static int copy_memory_regions_cow(ProcessControlBlock *parent,
         return -EINVAL;
     }
     
-    /* Share memory region list with COW - both processes reference the same regions */
     MemoryRegion *parent_region = parent->memory_regions;
     MemoryRegion *prev_child_region = nullptr;
     
     while (parent_region != nullptr) {
-        /* Share the same MemoryRegion object between parent and child */
-        /* Increment reference count for COW - both processes share this region */
-        atomic_fetch_add(&parent_region->ref_count, 1);
-        
-        /* Link the shared region into child's region list */
-        if (prev_child_region == nullptr) {
-            child->memory_regions = parent_region;
-        } else {
-            prev_child_region->next = parent_region;
+        /* Allocate NEW descriptor for child (own list node) */
+        MemoryRegion *child_region = ALLOC(MemoryRegion);
+        if (child_region == nullptr) {
+            fprintf(stderr, "PROCESS: Failed to allocate memory region\n");
+            return -ENOMEM;
         }
         
-        prev_child_region = parent_region;
+        /* Copy region metadata */
+        child_region->base = parent_region->base;
+        child_region->size = parent_region->size;
+        child_region->flags = parent_region->flags | MEM_FLAG_COW;
+        child_region->next = nullptr;
+        
+        /* Allocate shared refcount if not already allocated */
+        if (parent_region->cow_ref_count == nullptr) {
+            /* First fork - allocate shared refcount */
+            _Atomic(int) *shared_ref = ALLOC(_Atomic(int));
+            if (shared_ref == nullptr) {
+                FREE(child_region, MemoryRegion);
+                fprintf(stderr, "PROCESS: Failed to allocate shared refcount\n");
+                return -ENOMEM;
+            }
+            atomic_init(shared_ref, 2);  /* Parent + child */
+            parent_region->cow_ref_count = shared_ref;
+            child_region->cow_ref_count = shared_ref;
+        } else {
+            /* Already COW - increment existing shared refcount */
+            atomic_fetch_add(parent_region->cow_ref_count, 1);
+            child_region->cow_ref_count = parent_region->cow_ref_count;
+        }
+        
+        /* Initialize child's own refcount to 1 (for descriptor lifetime) */
+        atomic_init(&child_region->ref_count, 1);
+        
+        /* Link into child's region list */
+        if (prev_child_region == nullptr) {
+            child->memory_regions = child_region;
+        } else {
+            prev_child_region->next = child_region;
+        }
+        
+        prev_child_region = child_region;
         parent_region = parent_region->next;
     }
     
     return 0;
+}
+
+/**
+ * @brief Free a memory region with proper COW refcount handling
+ * 
+ * @param region Memory region to free
+ */
+static void free_memory_region(MemoryRegion *region) {
+    if (region == nullptr) {
+        return;
+    }
+    
+    /* Decrement shared refcount if COW */
+    if (region->cow_ref_count != nullptr) {
+        int old_count = atomic_fetch_sub(region->cow_ref_count, 1);
+        if (old_count == 1) {
+            /* Last reference - free the shared refcount and physical memory */
+            FREE(region->cow_ref_count, _Atomic(int));
+            free_memory(region->base, region->size);
+            printf("PROCESS: Freed COW physical memory at %p (last reference)\n", 
+                   region->base);
+        } else {
+            printf("PROCESS: Decremented COW refcount for %p (remaining: %d)\n",
+                   region->base, old_count - 1);
+        }
+    } else {
+        /* Not COW - free physical memory directly */
+        free_memory(region->base, region->size);
+        printf("PROCESS: Freed non-COW physical memory at %p\n", region->base);
+    }
+    
+    /* Always free the descriptor itself */
+    FREE(region, MemoryRegion);
 }
 
 /**
@@ -416,6 +482,15 @@ void process_exit(int exit_code) {
     
     /* Set exit time */
     pcb->exit_time = 0;  /* TODO: Get current timestamp */
+    
+    /* Free memory regions with proper COW handling */
+    MemoryRegion *region = pcb->memory_regions;
+    while (region != nullptr) {
+        MemoryRegion *next = region->next;
+        free_memory_region(region);
+        region = next;
+    }
+    pcb->memory_regions = nullptr;
     
     /* Close all file descriptors */
     if (pcb->fd_table != nullptr) {


### PR DESCRIPTION
## Summary

This PR fixes a critical list corruption bug (Bug #3) introduced by the PR #52 fix for COW memory regions.

## Problem

PR #52 fixed the use-after-free bug by making parent and child share the same `MemoryRegion` nodes. However, this introduced a new critical bug:

- Both parent and child now share the same linked list nodes (including `next` pointers)
- When one process removes a region, it frees the node unconditionally
- The other process still references the freed node → **dangling pointer and use-after-free**
- The linked list structure should be process-specific, but the actual memory region data and refcount should be shared

## Solution

Implement **two-level refcounting** with separate descriptors but shared physical memory tracking:

### Architecture

1. **Descriptor Refcount** (`ref_count`): Tracks the lifetime of the descriptor itself (process-local)
2. **Physical Memory Refcount** (`cow_ref_count`): Tracks the lifetime of shared physical memory (shared pointer)

### Key Changes

- **Updated `MemoryRegion` structure**: Added `cow_ref_count` field for shared physical memory tracking
- **Rewrote `copy_memory_regions_cow()`**: Allocates separate descriptors for each process with shared `cow_ref_count` pointer
- **Added `free_memory_region()` helper**: Properly handles COW refcount decrement and cleanup
- **Updated `process_exit()`**: Uses new cleanup function for proper memory region freeing
- **Updated `process_create_shm()` and `process_destroy_shm()`**: Implement shared refcount for explicit shared memory

## Benefits

✅ Process-local list management (no list corruption)  
✅ Correct shared memory lifetime tracking  
✅ No use-after-free or dangling pointers  
✅ Each process can independently manage its memory regions  
✅ Proper cleanup when processes exit in any order  
✅ Supports multiple forks (grandchildren, etc.)  
✅ Clean separation of concerns (descriptor vs. physical memory)

## Files Modified

- `bdi_kernel/process/process.h` - Added `cow_ref_count` field to `MemoryRegion`
- `bdi_kernel/process/process_lifecycle.c` - Rewrote COW implementation with two-level refcounting
- `bdi_kernel/process/process_ipc.c` - Updated shared memory functions
- `bdi_kernel/docs/PR51_BUG_FIXES.md` - Comprehensive documentation of Bug #3

## Testing Recommendations

1. **List independence test**: Fork process, have each process add/remove regions independently
2. **Descriptor lifetime test**: Verify descriptors are freed when process exits
3. **Physical memory lifetime test**: Verify physical memory is freed only when all processes exit
4. **Multiple fork test**: Fork multiple times, verify refcount increments correctly
5. **Grandchild test**: Fork chains (parent → child → grandchild)
6. **Shared memory test**: Create shared memory between processes, verify proper cleanup
7. **Race condition test**: Concurrent fork and exit operations

## Related Issues

- Fixes Bug #3 introduced in PR #52
- Related to Bug #2 (original COW use-after-free) fixed in PR #52
- Part of Phase 8: Process Management & Lifecycle

## Documentation

Complete documentation of the bug, root cause analysis, and solution is available in `bdi_kernel/docs/PR51_BUG_FIXES.md`.

---

**Note**: This PR should be merged into the `pr51-bugfix-process-table` branch, which will then be merged into `main` as part of PR #52.