### PR TITLE
Fix Phase 8 Bug: pcb_free COW refcount handling

### DIFF
--- a/bdi_kernel/process/process.h
+++ b/bdi_kernel/process/process.h
@@ -298,6 +298,9 @@ void process_shutdown(void);
  */
 void pcb_free(ProcessControlBlock *pcb);
 
+/* Free a memory region with proper COW refcount handling */
+void free_memory_region(MemoryRegion *region);
+
 /**
  * @brief Increment PCB reference count
  * 

--- a/bdi_kernel/process/process_lifecycle.c
+++ b/bdi_kernel/process/process_lifecycle.c
@@ -107,7 +107,7 @@ static int copy_memory_regions_cow(ProcessControlBlock *parent,
  * 
  * @param region Memory region to free
  */
-static void free_memory_region(MemoryRegion *region) {
+void free_memory_region(MemoryRegion *region) {
     if (region == nullptr) {
         return;
     }

--- a/bdi_kernel/process/process_manager.c
+++ b/bdi_kernel/process/process_manager.c
@@ -150,20 +150,11 @@ void pcb_free(ProcessControlBlock *pcb) {
         return;
     }
     
-    /* Free memory regions */
-    MemoryRegion *region = pcb->memory_regions;
-    while (region != nullptr) {
-        MemoryRegion *next = region->next;
-        
-        /* Decrement reference count */
-        uint32_t refs = atomic_fetch_sub(&region->ref_count, 1) - 1;
-        if (refs == 0) {
-            /* Free the region */
-            free_memory(region->base, region->size);
-            FREE(region, MemoryRegion);
-        }
-        
-        region = next;
+    /* Free memory regions using proper COW refcount handling */
+    while (pcb->memory_regions != nullptr) {
+        MemoryRegion *region = pcb->memory_regions;
+        pcb->memory_regions = region->next;
+        free_memory_region(region);
     }
     
     /* Free file descriptor table */


### PR DESCRIPTION
## Bug #1 (P1): process_manager.c - pcb_free ignores new cow_ref_count semantics

### Problem
The refcounting change in PR #54 split descriptor lifetime (`ref_count`) from shared physical memory (`cow_ref_count`), but `pcb_free()` was still freeing memory based solely on `region->ref_count`.

On any early cleanup path that calls `pcb_free` (e.g., when `copy_memory_regions_cow` fails during fork), each child descriptor has `ref_count == 1`, so the loop immediately released the underlying memory without decrementing the shared `cow_ref_count` that the parent still holds.

### Result
Parent keeps pointer to freed memory and will free it again on exit → **use-after-free or double-free**

### Solution
- Made `free_memory_region()` non-static in `process_lifecycle.c`
- Added declaration to `process.h`
- Updated `pcb_free()` to use `free_memory_region()` which properly handles both `ref_count` and `cow_ref_count` before freeing physical memory

### Files Changed
- `bdi_kernel/process/process_lifecycle.c` - Made `free_memory_region()` non-static
- `bdi_kernel/process/process.h` - Added function declaration
- `bdi_kernel/process/process_manager.c` - Updated `pcb_free()` to use the helper function

### Testing
The fix ensures that:
1. COW shared memory is only freed when the last reference is dropped
2. Both descriptor refcount and physical memory refcount are properly managed
3. No use-after-free or double-free conditions occur during process cleanup