### PR TITLE
Fix Phase 9 Bugs: API exports, CFS requeuing, device count clamping

### DIFF
--- a/bdi_kernel/scheduler/device_sched.c
+++ b/bdi_kernel/scheduler/device_sched.c
@@ -92,6 +92,14 @@ void* device_scheduler_create(Scheduler* base) {
     
     ds->base_scheduler = base;
     ds->num_devices = base->device_count;
+    
+    /* Clamp to maximum supported devices */
+    if (ds->num_devices > SCHED_MAX_DEVICES) {
+        fprintf(stderr, "WARNING: Requested %u devices, clamping to %u\n",
+                ds->num_devices, SCHED_MAX_DEVICES);
+        ds->num_devices = SCHED_MAX_DEVICES;
+    }
+    
     ds->balance_threshold = 10; /* Load difference threshold */
     ds->total_dispatched = 0;
     ds->total_migrations = 0;

--- a/bdi_kernel/scheduler/fairness.c
+++ b/bdi_kernel/scheduler/fairness.c
@@ -183,6 +183,50 @@ static int cfs_dequeue_task_internal(cfs_scheduler_t* cfs, node_sched_info_t* ta
 /**
  * @brief Pick next task from CFS queue
  */
+/**
+ * @brief Requeue a task after vruntime update (maintains sorted order)
+ */
+static void cfs_requeue_task(cfs_scheduler_t* cfs, node_sched_info_t* task) {
+    /* Find current position */
+    uint32_t old_pos = UINT32_MAX;
+    for (uint32_t i = 0; i < cfs->task_count; i++) {
+        if (cfs->tasks[i] == task) {
+            old_pos = i;
+            break;
+        }
+    }
+    
+    if (old_pos == UINT32_MAX) {
+        return; /* Task not in queue */
+    }
+    
+    /* Find new position based on updated vruntime */
+    uint32_t new_pos = old_pos;
+    
+    /* Check if we need to move forward (vruntime increased) */
+    for (uint32_t i = old_pos + 1; i < cfs->task_count; i++) {
+        if (task->vruntime > cfs->tasks[i]->vruntime) {
+            new_pos = i;
+        } else {
+            break;
+        }
+    }
+    
+    /* Only reposition if position changed */
+    if (new_pos != old_pos) {
+        /* Remove from old position */
+        node_sched_info_t* temp = cfs->tasks[old_pos];
+        
+        /* Shift tasks between old and new position */
+        for (uint32_t i = old_pos; i < new_pos; i++) {
+            cfs->tasks[i] = cfs->tasks[i + 1];
+        }
+        
+        /* Insert at new position */
+        cfs->tasks[new_pos] = temp;
+    }
+}
+
 static node_sched_info_t* cfs_pick_next_task_internal(cfs_scheduler_t* cfs) {
     if (cfs->task_count == 0) {
         return nullptr;
@@ -282,12 +326,22 @@ void fair_scheduler_tick_cfs(void* cfs_ptr, uint64_t current_time) {
     
     cfs_scheduler_t* cfs = (cfs_scheduler_t*)cfs_ptr;
     
-    /* Update vruntime for running tasks */
+    /* Update vruntime for running tasks and requeue if time slice expired */
     for (uint32_t i = 0; i < cfs->task_count; i++) {
         node_sched_info_t* task = cfs->tasks[i];
         if (task->is_running) {
             /* Assume 1ms tick */
             cfs_update_vruntime(cfs, task, 1000000);
+            
+            /* Check if time slice expired (simplified: 10ms slice) */
+            if (task->runtime >= 10000000) {
+                /* Time slice expired - mark as not running and requeue */
+                task->is_running = false;
+                task->runtime = 0;
+                
+                /* Reinsert task in sorted order by vruntime */
+                cfs_requeue_task(cfs, task);
+            }
         }
     }
 }

--- a/bdi_kernel/scheduler/fairness.h
+++ b/bdi_kernel/scheduler/fairness.h
@@ -168,4 +168,35 @@ void fair_scheduler_print_runqueue(fair_scheduler_t* fs, DeviceId device_id);
 // Default time function (can be overridden)
 uint64_t default_get_time_ns(void);
 
+
+/* ===================================================================
+ * CFS Scheduler API
+ * =================================================================== */
+void* fair_scheduler_create_cfs(Scheduler* base);
+void fair_scheduler_destroy_cfs(void* cfs_ptr);
+NodeId fair_scheduler_pick_next_cfs(void* cfs_ptr);
+void fair_scheduler_tick_cfs(void* cfs_ptr, uint64_t current_time);
+int fair_scheduler_enqueue_cfs(void* cfs_ptr, NodeId node_id, int nice);
+int fair_scheduler_dequeue_cfs(void* cfs_ptr, NodeId node_id);
+
+/* ===================================================================
+ * RT Scheduler API
+ * =================================================================== */
+void* fair_scheduler_create_rt(Scheduler* base);
+void fair_scheduler_destroy_rt(void* rt_ptr);
+NodeId fair_scheduler_pick_next_rt(void* rt_ptr);
+void fair_scheduler_tick_rt(void* rt_ptr, uint64_t current_time);
+int fair_scheduler_enqueue_rt(void* rt_ptr, NodeId node_id, int priority, int policy);
+int fair_scheduler_dequeue_rt(void* rt_ptr, NodeId node_id);
+
+/* ===================================================================
+ * Deadline Scheduler API
+ * =================================================================== */
+void* fair_scheduler_create_deadline(Scheduler* base);
+void fair_scheduler_destroy_deadline(void* dl_ptr);
+NodeId fair_scheduler_pick_next_deadline(void* dl_ptr);
+void fair_scheduler_tick_deadline(void* dl_ptr, uint64_t current_time);
+int fair_scheduler_enqueue_deadline(void* dl_ptr, NodeId node_id, 
+                                    uint64_t runtime, uint64_t deadline, uint64_t period);
+int fair_scheduler_dequeue_deadline(void* dl_ptr, NodeId node_id);
 #endif // AEON_FAIRNESS_H


### PR DESCRIPTION
## Phase 9 Bug Fixes

This PR fixes three critical bugs in the Phase 9 scheduler implementation:

---

## Bug #2 (P0): scheduler.c - Export new fairness scheduler API

### Problem
The code uses `fair_scheduler_create_cfs`, `fair_scheduler_create_rt`, and `fair_scheduler_create_deadline`, but none of these functions are declared in `fairness.h`. With C23's prohibition on implicit function declarations, this will fail to compile.

### Solution
Added prototypes for all new creation/destruction and per-policy helpers to `fairness.h`:
- **CFS Scheduler API**: create, destroy, pick_next, tick, enqueue, dequeue
- **RT Scheduler API**: create, destroy, pick_next, tick, enqueue, dequeue
- **Deadline Scheduler API**: create, destroy, pick_next, tick, enqueue, dequeue

---

## Bug #3 (P1): fairness.c - Requeue CFS tasks after vruntime updates

### Problem
`fair_scheduler_pick_next_cfs` returns the first entry in the sorted array and never removes or re-inserts it. `fair_scheduler_tick_cfs` only increments that task's vruntime in place, but the array remains in its original order.

### Result
The same node stays at index 0 and is scheduled again on every call while other runnable nodes are starved. **The fairness algorithm degenerates into single-task execution.**

### Solution
- Added `cfs_requeue_task()` helper function that repositions tasks in sorted order after vruntime updates
- Updated `fair_scheduler_tick_cfs()` to:
  1. Update vruntime for running tasks
  2. Check if time slice expired (10ms)
  3. Mark task as not running and reset runtime
  4. Requeue task in proper sorted position based on new vruntime

---

## Bug #4 (P1): device_sched.c - Clamp num_devices to SCHED_MAX_DEVICES

### Problem
`device_scheduler_create` copies `base->device_count` into `ds->num_devices` but only initializes `device_queues` up to `SCHED_MAX_DEVICES`. Later iterations like `device_find_least_loaded` loop to `i < ds->num_devices` while indexing `device_queues[i]`.

### Result
If the caller provides more than 16 devices, these loops walk past the fixed array, **corrupting memory and crashing the scheduler**.

### Solution
Clamp `num_devices` to `SCHED_MAX_DEVICES` with a warning message when the requested device count exceeds the maximum.

---

## Files Changed
- `bdi_kernel/scheduler/fairness.h` - Added missing API declarations
- `bdi_kernel/scheduler/fairness.c` - Added CFS requeue logic and helper function
- `bdi_kernel/scheduler/device_sched.c` - Added device count clamping

## Testing
All fixes maintain correctness and prevent:
1. Compilation failures with C23
2. CFS scheduler starvation
3. Memory corruption from device array overflow