### PR TITLE
Fix Phase 9 Scheduler Bugs: CFS iteration and API naming

### DIFF
--- a/bdi_kernel/scheduler/fairness.c
+++ b/bdi_kernel/scheduler/fairness.c
@@ -326,7 +326,11 @@ void fair_scheduler_tick_cfs(void* cfs_ptr, uint64_t current_time) {
     
     cfs_scheduler_t* cfs = (cfs_scheduler_t*)cfs_ptr;
     
-    /* Update vruntime for running tasks and requeue if time slice expired */
+    /* Temporary array to collect tasks that need requeueing */
+    node_sched_info_t* requeue_list[256];
+    uint32_t requeue_count = 0;
+    
+    /* Update vruntime for running tasks and collect those needing requeue */
     for (uint32_t i = 0; i < cfs->task_count; i++) {
         node_sched_info_t* task = cfs->tasks[i];
         if (task->is_running) {
@@ -335,14 +339,21 @@ void fair_scheduler_tick_cfs(void* cfs_ptr, uint64_t current_time) {
             
             /* Check if time slice expired (simplified: 10ms slice) */
             if (task->runtime >= 10000000) {
-                /* Time slice expired - mark as not running and requeue */
+                /* Time slice expired - mark as not running and collect for requeue */
                 task->is_running = false;
                 task->runtime = 0;
                 
-                /* Reinsert task in sorted order by vruntime */
-                cfs_requeue_task(cfs, task);
+                /* Add to requeue list instead of requeueing immediately */
+                if (requeue_count < 256) {
+                    requeue_list[requeue_count++] = task;
+                }
             }
         }
+    }
+    
+    /* Now requeue all collected tasks after iteration is complete */
+    for (uint32_t i = 0; i < requeue_count; i++) {
+        cfs_requeue_task(cfs, requeue_list[i]);
     }
 }
 

--- a/bdi_kernel/scheduler/fairness.h
+++ b/bdi_kernel/scheduler/fairness.h
@@ -176,8 +176,8 @@ void* fair_scheduler_create_cfs(Scheduler* base);
 void fair_scheduler_destroy_cfs(void* cfs_ptr);
 NodeId fair_scheduler_pick_next_cfs(void* cfs_ptr);
 void fair_scheduler_tick_cfs(void* cfs_ptr, uint64_t current_time);
-int fair_scheduler_enqueue_cfs(void* cfs_ptr, NodeId node_id, int nice);
-int fair_scheduler_dequeue_cfs(void* cfs_ptr, NodeId node_id);
+int fair_scheduler_add_cfs_node(void* cfs_ptr, NodeId node_id, int32_t priority);
+int fair_scheduler_remove_cfs_node(void* cfs_ptr, NodeId node_id);
 
 /* ===================================================================
  * RT Scheduler API
@@ -186,8 +186,8 @@ void* fair_scheduler_create_rt(Scheduler* base);
 void fair_scheduler_destroy_rt(void* rt_ptr);
 NodeId fair_scheduler_pick_next_rt(void* rt_ptr);
 void fair_scheduler_tick_rt(void* rt_ptr, uint64_t current_time);
-int fair_scheduler_enqueue_rt(void* rt_ptr, NodeId node_id, int priority, int policy);
-int fair_scheduler_dequeue_rt(void* rt_ptr, NodeId node_id);
+int fair_scheduler_add_rt_node(void* rt_ptr, NodeId node_id, SchedPolicy policy, int32_t priority);
+int fair_scheduler_remove_rt_node(void* rt_ptr, NodeId node_id);
 
 /* ===================================================================
  * Deadline Scheduler API
@@ -196,7 +196,6 @@ void* fair_scheduler_create_deadline(Scheduler* base);
 void fair_scheduler_destroy_deadline(void* dl_ptr);
 NodeId fair_scheduler_pick_next_deadline(void* dl_ptr);
 void fair_scheduler_tick_deadline(void* dl_ptr, uint64_t current_time);
-int fair_scheduler_enqueue_deadline(void* dl_ptr, NodeId node_id, 
-                                    uint64_t runtime, uint64_t deadline, uint64_t period);
-int fair_scheduler_dequeue_deadline(void* dl_ptr, NodeId node_id);
+int fair_scheduler_add_dl_node(void* dl_ptr, NodeId node_id);
+int fair_scheduler_remove_dl_node(void* dl_ptr, NodeId node_id);
 #endif // AEON_FAIRNESS_H


### PR DESCRIPTION
## Phase 9 Scheduler Bug Fixes

This PR fixes two critical bugs discovered in the Phase 9 scheduler implementation:

---

## Bug #1 (P1): CFS requeueing during iteration

### Problem
`fair_scheduler_tick_cfs` calls `cfs_requeue_task` while iterating forward through the task array. Since `cfs_requeue_task` shifts array elements to maintain sorted order, this causes the iteration to skip tasks that get shifted into already-visited positions.

### Impact
Tasks can be skipped during vruntime updates and time slice checks, leading to incorrect scheduling behavior and potential starvation.

### Solution
- Modified `fair_scheduler_tick_cfs` to collect tasks needing requeue in a temporary array during iteration
- Requeue all collected tasks after the main loop completes
- This prevents array mutation during iteration and ensures all tasks are processed correctly

### Code Changes
```c
// Before: Immediate requeueing during iteration
for (uint32_t i = 0; i < cfs->task_count; i++) {
    if (task->runtime >= 10000000) {
        cfs_requeue_task(cfs, task);  // ❌ Modifies array during iteration
    }
}

// After: Deferred requeueing
node_sched_info_t* requeue_list[256];
uint32_t requeue_count = 0;

for (uint32_t i = 0; i < cfs->task_count; i++) {
    if (task->runtime >= 10000000) {
        requeue_list[requeue_count++] = task;  // ✅ Collect for later
    }
}

for (uint32_t i = 0; i < requeue_count; i++) {
    cfs_requeue_task(cfs, requeue_list[i]);  // ✅ Requeue after iteration
}
```

---

## Bug #2 (P1): Wrong API names in fairness.h

### Problem
The header file `fairness.h` declares functions with incorrect names:
- Declares: `fair_scheduler_enqueue_cfs`, `fair_scheduler_dequeue_cfs`
- Actual functions: `fair_scheduler_add_cfs_node`, `fair_scheduler_remove_cfs_node`

This mismatch exists for all three scheduler types (CFS, RT, Deadline).

### Impact
- Code using the header will fail to link
- `scheduler.c` already calls the correct function names, but the header doesn't match
- With C23's prohibition on implicit function declarations, this will cause compilation failures

### Solution
Updated `fairness.h` to declare the actual function names that exist in `fairness.c`:

**CFS Scheduler:**
- ❌ `fair_scheduler_enqueue_cfs` → ✅ `fair_scheduler_add_cfs_node`
- ❌ `fair_scheduler_dequeue_cfs` → ✅ `fair_scheduler_remove_cfs_node`

**RT Scheduler:**
- ❌ `fair_scheduler_enqueue_rt` → ✅ `fair_scheduler_add_rt_node`
- ❌ `fair_scheduler_dequeue_rt` → ✅ `fair_scheduler_remove_rt_node`

**Deadline Scheduler:**
- ❌ `fair_scheduler_enqueue_deadline` → ✅ `fair_scheduler_add_dl_node`
- ❌ `fair_scheduler_dequeue_deadline` → ✅ `fair_scheduler_remove_dl_node`

Also corrected function signatures to match implementations (e.g., `int32_t priority` instead of `int nice`).

---

## Files Changed
- `bdi_kernel/scheduler/fairness.c` - Fixed CFS iteration bug with deferred requeueing
- `bdi_kernel/scheduler/fairness.h` - Corrected API function names to match implementation

## Testing
- Both fixes maintain correctness and prevent:
  1. Task skipping during CFS scheduling ticks
  2. Compilation/linking failures with C23 strict function declarations

## Related
This PR addresses bugs discovered after PR #57 was merged.