### PR TITLE
Fix AHCI PRDT entry to preserve 16-byte hardware layout (Phase 10 P1 Bug)

### DIFF
--- a/bdi_kernel/storage/ahci/ahci.c
+++ b/bdi_kernel/storage/ahci/ahci.c
@@ -266,7 +266,7 @@ static int ahci_send_command(ahci_controller_t* ctrl, uint32_t port_num, uint8_t
     if (buffer) {
         cmd_table->prdt[0].dba = (uint64_t)(uintptr_t)buffer;
         cmd_table->prdt[0].dbc = (count * 512) - 1; // 0-based byte count
-        cmd_table->prdt[0].i = 1; // Interrupt on completion
+        cmd_table->prdt[0].dbc |= (1U << 31); // Interrupt on completion
     }
     
     // Issue command
@@ -453,7 +453,7 @@ static inline void ahci_setup_prdt_simd(ahci_prdt_entry_t* prdt,
         prdt[i].dba = phys_addrs[i] & 0xFFFFFFFF;
         prdt[i].dbau = (phys_addrs[i] >> 32) & 0xFFFFFFFF;
         prdt[i].dbc = (sizes[i] - 1) & 0x3FFFFF;  // Size - 1, max 4MB
-        prdt[i].i = 0;  // No interrupt on completion for individual entries
+        // Bit 31 (interrupt flag) is 0 due to 0x3FFFFF mask above
     }
 }
 

--- a/bdi_kernel/storage/ahci/ahci.h
+++ b/bdi_kernel/storage/ahci/ahci.h
@@ -259,9 +259,11 @@ typedef struct {
     uint32_t dba;      // Data Base Address (lower 32 bits)
     uint32_t dbau;     // Data Base Address Upper (upper 32 bits)
     uint32_t reserved;
-    uint32_t dbc;      // Data Byte Count (bits 0-21)
-    uint32_t i;        // Interrupt on completion flag (bit 31)
+    uint32_t dbc;      // Data Byte Count (bits 0-21), I flag (bit 31)
 } __attribute__((packed)) ahci_prdt_entry_t;
+
+// Verify AHCI PRDT entry is exactly 16 bytes per hardware spec
+_Static_assert(sizeof(ahci_prdt_entry_t) == 16, "AHCI PRDT entry must be 16 bytes");
 
 typedef struct {
     uint32_t port_num;


### PR DESCRIPTION
## Critical Bug Fix: AHCI PRDT Entry Layout (P1)

This PR fixes a **critical hardware specification violation** in the AHCI PRDT (Physical Region Descriptor Table) entry structure.

### Problem
The previous fix in PR #62 added a separate `uint32_t i` field to `ahci_prdt_entry_t`, which **expanded the struct from 16 to 20 bytes**. This violates the AHCI hardware specification, which mandates that PRDT entries must be exactly **16 bytes**.

**AHCI Specification:**
- PRDT entry: exactly 16 bytes
- DBC field (offset 0x0C, 4 bytes):
  - Bits 0-21: Data Byte Count (22 bits, max 4MB)
  - Bits 22-30: Reserved
  - **Bit 31: Interrupt on completion flag (I)**

**Impact of 20-byte struct:**
- DMA engines receive corrupted descriptors
- Interrupt flags are misplaced
- Command tables overflow their allocated space
- Hardware cannot properly process I/O requests

### Solution
✅ **Remove the separate `uint32_t i` field**
✅ **Keep struct at exactly 16 bytes (4 uint32_t fields)**
✅ **Use bit operations on `dbc` field for interrupt flag (bit 31)**
✅ **Add `_Static_assert` to verify 16-byte size**

### Changes

**bdi_kernel/storage/ahci/ahci.h:**
```c
typedef struct {
    uint32_t dba;      // Data Base Address (lower 32 bits)
    uint32_t dbau;     // Data Base Address Upper (upper 32 bits)
    uint32_t reserved;
    uint32_t dbc;      // Data Byte Count (bits 0-21), I flag (bit 31)
} __attribute__((packed)) ahci_prdt_entry_t;

// Verify AHCI PRDT entry is exactly 16 bytes per hardware spec
_Static_assert(sizeof(ahci_prdt_entry_t) == 16, "AHCI PRDT entry must be 16 bytes");
```

**bdi_kernel/storage/ahci/ahci.c:**
- Line 269: Changed `prdt[0].i = 1` → `prdt[0].dbc |= (1U << 31)` to set interrupt flag
- Line 456: Removed `prdt[i].i = 0` (bit 31 already 0 from `0x3FFFFF` mask)

### Verification
✅ Struct size verified: **16 bytes** (correct)
✅ Bit operations tested: interrupt flag properly set/cleared in bit 31
✅ Byte count preserved: bits 0-21 remain intact
✅ No remaining `.i` field references in code

### Testing
```c
ahci_prdt_entry_t entry = {0};
entry.dbc = (4096 - 1) & 0x3FFFFF;  // 4KB, no interrupt → bit 31 = 0
entry.dbc |= (1U << 31);             // Set interrupt → bit 31 = 1
// Byte count preserved: (entry.dbc & 0x3FFFFF) + 1 = 4096 bytes ✓
```

This fix ensures the AHCI driver correctly interfaces with hardware DMA engines and prevents descriptor corruption.