### PR TITLE
Phase 11: Fix errno.h includes and reject atomic batches (Bugs 2, 3, 4)

### DIFF
--- a/bdi_kernel/syscalls/syscall_fast_path.c
+++ b/bdi_kernel/syscalls/syscall_fast_path.c
@@ -23,6 +23,7 @@
  */
 
 #include "syscalls.h"
+#include <errno.h>
 #include "../process/process.h"
 #include "../scheduler/scheduler.h"
 #include <stdio.h>
@@ -271,6 +272,12 @@ int64_t sys_batch(const syscall_args_t *args) {
     
     uint32_t success_count = 0;
     bool atomic_batch = (params->flags & 0x1) != 0;
+
+    /* Atomic batches not yet supported - reject early */
+    if (atomic_batch) {
+        printf("sys_batch: Atomic batches not yet implemented\n");
+        return -ENOSYS;
+    }
     
     /* Execute each syscall in the batch */
     for (uint32_t i = 0; i < params->count; i++) {
@@ -283,14 +290,6 @@ int64_t sys_batch(const syscall_args_t *args) {
         
         if (result >= 0) {
             success_count++;
-        } else if (atomic_batch) {
-            /* Atomic batch: rollback on first error */
-            printf("sys_batch: Atomic batch failed at syscall %u (error %ld)\n", 
-                   i, result);
-            
-            /* TODO: Implement rollback mechanism for atomic batches */
-            /* For now, just return the error */
-            return result;
         }
     }
     

--- a/bdi_kernel/syscalls/syscall_table.c
+++ b/bdi_kernel/syscalls/syscall_table.c
@@ -18,6 +18,7 @@
  */
 
 #include "syscalls.h"
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
## Phase 11 Bug Fixes

This PR fixes three critical bugs in the Phase 11 syscall interface implementation:

### Bug 2 (P0): Add errno.h include to syscall_table.c
- **Problem**: File uses errno constants like `-EINVAL`, `-EBUSY`, `-ENOSYS`, `-EAGAIN` but doesn't include `<errno.h>`
- **Impact**: Compilation failure due to undefined macros
- **Solution**: Added `#include <errno.h>` after `syscalls.h`

### Bug 3 (P0): Add errno.h include to syscall_fast_path.c
- **Problem**: Fast-path handlers return errno values (`-ENOMEM`, `-EFAULT`, `-EINVAL`) but missing the header
- **Impact**: Compilation failure
- **Solution**: Added `#include <errno.h>` after `syscalls.h`

### Bug 4 (P1): Reject atomic batches without rollback
- **Problem**: The `sys_batch()` function sets an `atomic_batch` flag and documents "rollback on first error," but if any syscall fails, the function simply returns the error after some operations may already have succeeded
- **Impact**: Callers requesting atomic behavior will see partially applied side effects, defeating the flag's purpose
- **Solution**: 
  - Added early rejection of atomic batches with `-ENOSYS`
  - Removed incomplete rollback handling code from the loop
  - Atomic batches will be rejected until proper transactional semantics are implemented

### Changes Made
- `bdi_kernel/syscalls/syscall_table.c`: Added `#include <errno.h>`
- `bdi_kernel/syscalls/syscall_fast_path.c`: 
  - Added `#include <errno.h>`
  - Added early rejection check for atomic batches
  - Removed incomplete atomic batch rollback code

### Testing
These fixes resolve compilation issues and prevent incorrect atomic batch behavior until proper transactional support is implemented.