### PR TITLE
Phase 10: Fix AHCI PRDT interrupt bit setting (Bug 1)

### DIFF
--- a/bdi_kernel/storage/ahci/ahci.c
+++ b/bdi_kernel/storage/ahci/ahci.c
@@ -266,7 +266,7 @@ static int ahci_send_command(ahci_controller_t* ctrl, uint32_t port_num, uint8_t
     if (buffer) {
         cmd_table->prdt[0].dba = (uint64_t)(uintptr_t)buffer;
         cmd_table->prdt[0].dbc = (count * 512) - 1; // 0-based byte count
-        cmd_table->prdt[0].dbc |= (1U << 31); // Interrupt on completion
+        cmd_table->prdt[0].i = 1; // Interrupt on completion
     }
     
     // Issue command


### PR DESCRIPTION
## Phase 10 Bug Fix

This PR fixes a critical bug in the AHCI driver's PRDT (Physical Region Descriptor Table) interrupt handling.

### Bug 1 (P1): Interrupt bit no longer set in PRDT entry

**Problem:**
- The code was attempting to set the interrupt-on-completion bit using: `cmd_table->prdt[0].dbc |= (1U << 31)`
- However, `cmd_table->prdt` elements are of type `ahci_prd_t`, which uses bitfields:
  - `dbc` is a 22-bit bitfield (bits 0-21) for the data byte count
  - `i` is a separate 1-bit bitfield (bit 31) for interrupt-on-completion
- OR-ing bit 31 into the `dbc` bitfield gets truncated to 22 bits
- This leaves the `i` (interrupt) bitfield untouched at 0

**Impact:**
- Commands that relied on the interrupt-on-completion flag will no longer raise interrupts when the transfer completes
- This regresses the behavior that previously worked with direct bitfield assignment
- Can cause command timeouts and performance degradation

**Solution:**
- Changed from: `cmd_table->prdt[0].dbc |= (1U << 31);`
- Changed to: `cmd_table->prdt[0].i = 1;`
- This correctly sets the interrupt bitfield in the hardware structure

### Technical Details

The `ahci_prd_t` structure is defined as:
```c
typedef struct {
    uint64_t dba;           // Data Base Address
    uint32_t reserved;
    uint32_t dbc:22;        // Data Byte Count (bits 0-21)
    uint32_t reserved2:9;   // Reserved (bits 22-30)
    uint32_t i:1;           // Interrupt on Completion (bit 31)
} __attribute__((packed)) ahci_prd_t;
```

The fix ensures that the interrupt bit is properly set in the hardware structure, allowing AHCI commands to correctly signal completion via interrupts.

### Changes Made
- `bdi_kernel/storage/ahci/ahci.c`: Fixed interrupt bit setting to use the `i` bitfield directly

### Testing
This fix restores the correct interrupt-on-completion behavior for AHCI storage operations.