### PR TITLE
Fix 3 Critical Bugs in Phase 13 Backend Acceleration

### DIFF
--- a/bdi_kernel/backend/fpga_backend.c
+++ b/bdi_kernel/backend/fpga_backend.c
@@ -1,3 +1,4 @@
+
 // ===================================================================
 // DESC: Implements the conceptual FPGA backend API for
 //       synthesizing and loading bitstreams.
@@ -293,6 +294,10 @@ static void add_to_cache(FpgaBitstream* bs) {
     atomic_store(&bitstream->is_loaded, true);
     bitstream->region_id = region_id;
     region->current_bitstream = bitstream;
+    
+    // Increment reference count to prevent premature freeing
+    atomic_fetch_add(&bitstream->ref_count, 1);
+    
     atomic_store(&region->is_occupied, true);
     
     printf("FPGA_BACKEND: Bitstream loaded successfully to region %d.\n", region_id);
@@ -307,8 +312,14 @@ static void add_to_cache(FpgaBitstream* bs) {
     FpgaRegion* region = &fpga_state.regions[region_id];
     
     if (region->current_bitstream != nullptr) {
-        atomic_store(&region->current_bitstream->is_loaded, false);
-        region->current_bitstream->region_id = -1;
+        FpgaBitstream* bitstream = region->current_bitstream;
+        
+        atomic_store(&bitstream->is_loaded, false);
+        bitstream->region_id = -1;
+        
+        // Decrement reference count when unloading
+        atomic_fetch_sub(&bitstream->ref_count, 1);
+        
         region->current_bitstream = nullptr;
     }
     

--- a/bdi_kernel/backend/gpu_backend.c
+++ b/bdi_kernel/backend/gpu_backend.c
@@ -1,3 +1,4 @@
+
 // ===================================================================
 // DESC: Implements the conceptual GPU backend API.
 //       This simulates a wrapper around a real GPU framework like CUDA.
@@ -8,6 +9,20 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+// ============================================================================
+// Allocation Tracking for Memory Accounting
+// ============================================================================
+
+// Allocation metadata for tracking sizes
+typedef struct {
+    void* ptr;
+    size_t size;
+} GpuAllocation;
+
+#define MAX_GPU_ALLOCATIONS 1024
+static GpuAllocation gpu_allocations[MAX_GPU_ALLOCATIONS];
+static _Atomic uint32_t gpu_allocation_count = 0;
 
 // ============================================================================
 // Kernel Compilation Cache
@@ -173,12 +188,7 @@ static AsyncExecutor async_executor = {
 // ============================================================================
 // CUDA/OpenCL Abstraction Layer
 // ============================================================================
-
-typedef enum {
-    GPU_BACKEND_CUDA = 0,
-    GPU_BACKEND_OPENCL = 1,
-    GPU_BACKEND_SIMULATION = 2
-} GpuBackendType;
+// NOTE: GpuBackendType typedef removed - already declared in gpu_backend.h
 
 typedef struct {
     GpuBackendType type;
@@ -235,6 +245,13 @@ static GpuDeviceState gpu_state = {
     printf("GPU_BACKEND: Initializing GPU (%s)... OK.\n", backends[current_backend].name);
     atomic_store(&gpu_state.mem_allocated, 0);
     atomic_store(&gpu_state.active_kernels, 0);
+    
+    // Initialize allocation tracking
+    atomic_store(&gpu_allocation_count, 0);
+    for (int i = 0; i < MAX_GPU_ALLOCATIONS; i++) {
+        gpu_allocations[i].ptr = nullptr;
+        gpu_allocations[i].size = 0;
+    }
     
     // Initialize streams
     for (int i = 0; i < GPU_MAX_STREAMS; i++) {
@@ -301,6 +318,14 @@ void gpu_shutdown(void) {
     void* ptr = backends[current_backend].alloc_func(size_bytes);
     if (ptr != nullptr) {
         atomic_fetch_add(&gpu_state.mem_allocated, size_bytes);
+        
+        // Track allocation for proper memory accounting
+        uint32_t idx = atomic_fetch_add(&gpu_allocation_count, 1);
+        if (idx < MAX_GPU_ALLOCATIONS) {
+            gpu_allocations[idx].ptr = ptr;
+            gpu_allocations[idx].size = size_bytes;
+        }
+        
         printf("GPU_BACKEND: Allocated %zu bytes on device (total: %zu).\n", 
                size_bytes, atomic_load(&gpu_state.mem_allocated));
     }
@@ -310,6 +335,23 @@ void gpu_shutdown(void) {
 void gpu_free(void* device_ptr) {
     if (device_ptr == nullptr) {
         return;
+    }
+    
+    // Find allocation and decrement mem_allocated
+    uint32_t count = atomic_load(&gpu_allocation_count);
+    for (uint32_t i = 0; i < count && i < MAX_GPU_ALLOCATIONS; i++) {
+        if (gpu_allocations[i].ptr == device_ptr) {
+            size_t size = gpu_allocations[i].size;
+            atomic_fetch_sub(&gpu_state.mem_allocated, size);
+            
+            // Clear entry
+            gpu_allocations[i].ptr = nullptr;
+            gpu_allocations[i].size = 0;
+            
+            printf("GPU_BACKEND: Freed %zu bytes (total: %zu).\n",
+                   size, atomic_load(&gpu_state.mem_allocated));
+            break;
+        }
     }
     
     backends[current_backend].free_func(device_ptr);


### PR DESCRIPTION
## Bug Fixes for Phase 13: Backend Acceleration

This PR fixes three critical bugs identified during code review of the Phase 13 implementation.

### Bug 1 (P0 - Build Failure): Duplicate GpuBackendType Typedef
**File:** `bdi_kernel/backend/gpu_backend.c`

**Issue:** The header `gpu_backend.h` already declares `GpuBackendType`, but the .c file redeclared it at lines 177-181, causing a redefinition error that prevented compilation.

**Fix:** Removed the duplicate typedef enum from gpu_backend.c and added a comment noting the typedef is in the header.

### Bug 2 (P1 - Memory Accounting): Missing mem_allocated Decrement
**File:** `bdi_kernel/backend/gpu_backend.c`

**Issue:** `gpu_alloc` increments `gpu_state.mem_allocated` for capacity tracking, but `gpu_free` never decremented it. After allocations/frees, the counter only grew, causing subsequent `gpu_alloc` calls to hit the GPU_MEMORY_CAPACITY check and fail even though memory was released.

**Fix:** 
- Added `GpuAllocation` tracking structure to store allocation metadata (pointer + size)
- Modified `gpu_alloc` to track each allocation in the `gpu_allocations` array
- Modified `gpu_free` to find the allocation, decrement `mem_allocated` by the correct size, and clear the tracking entry
- Added initialization of tracking array in `gpu_init`

### Bug 3 (P1 - Reference Counting): Missing ref_count Increment
**File:** `bdi_kernel/backend/fpga_backend.c`

**Issue:** Loading a bitstream into a region marked it as loaded but never incremented `ref_count`. If the caller released or the cache evicted that bitstream while the region still pointed to it, the region held a dangling pointer. `fpga_free_bitstream` frees the object once the count reaches zero.

**Fix:**
- Added `atomic_fetch_add(&bitstream->ref_count, 1)` in `fpga_load_bitstream_region` after assigning the bitstream to the region
- Added `atomic_fetch_sub(&bitstream->ref_count, 1)` in `fpga_unload_region` before clearing the pointer
- Ensures proper reference counting lifecycle for bitstreams loaded in regions

## Testing
All fixes maintain C23 features (nullptr, [[nodiscard]], _Atomic) and proper atomic operations for thread safety.

## Impact
- **Bug 1:** Fixes build failure - code now compiles
- **Bug 2:** Fixes memory accounting - prevents false out-of-memory errors
- **Bug 3:** Fixes memory safety - prevents use-after-free and dangling pointers

Closes issues identified in Phase 13 code review.