### PR TITLE
Fix Phase 14 Critical Bugs: job_count overflow and missing stdint.h

### DIFF
--- a/bdi_kernel/tests/stress_tests.c
+++ b/bdi_kernel/tests/stress_tests.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include <stdint.h>
 
 // Stress test configuration
 #define STRESS_DURATION_SECONDS 60

--- a/bdi_kernel/userland/bdi_shell.c
+++ b/bdi_kernel/userland/bdi_shell.c
@@ -158,8 +158,9 @@ int shell_launch_job(char** args, bool background) {
         // Parent process
         if (background) {
             // Add to job list
-            uint32_t job_count = atomic_fetch_add(&shell_state.job_count, 1);
+            uint32_t job_count = atomic_load(&shell_state.job_count);
             if (job_count < SHELL_MAX_JOBS) {
+                atomic_fetch_add(&shell_state.job_count, 1);
                 shell_state.jobs[job_count].job_id = job_count + 1;
                 shell_state.jobs[job_count].pid = pid;
                 strncpy(shell_state.jobs[job_count].command, args[0], 


### PR DESCRIPTION
## 🐛 Bug Fixes for Phase 14

This PR fixes two critical bugs identified in the Phase 14 implementation:

### Bug 1: Job Count Overflow in bdi_shell.c ✅

**Problem:**
The background job handling code always incremented `shell_state.job_count` via `atomic_fetch_add` even when the job list was already at `SHELL_MAX_JOBS` capacity. Once 32 background jobs had been launched, the counter continued to grow while no entries were stored, yet other code (`shell_cleanup`, `shell_fg`, `shell_bg`, `shell_list_jobs`) iterated up to `job_count`, leading to out-of-bounds reads and writes past the `shell_state.jobs[]` array.

**Fix:**
Changed the logic to use `atomic_load` first to check capacity, then only increment with `atomic_fetch_add` after confirming a slot is available. This prevents the counter from exceeding `SHELL_MAX_JOBS` and eliminates out-of-bounds access.

**Code Change:**
```c
// Before (buggy):
uint32_t job_count = atomic_fetch_add(&shell_state.job_count, 1);
if (job_count < SHELL_MAX_JOBS) {
    // Add job...
}

// After (fixed):
uint32_t job_count = atomic_load(&shell_state.job_count);
if (job_count < SHELL_MAX_JOBS) {
    atomic_fetch_add(&shell_state.job_count, 1);
    // Add job...
}
```

### Bug 2: Missing stdint.h Include in stress_tests.c ✅

**Problem:**
The stress test file uses `_Atomic uint64_t operations_completed` but does not include `<stdint.h>`, causing compilation errors because `uint64_t` is undefined.

**Fix:**
Added `#include <stdint.h>` to the includes section.

## 📝 Files Changed

- `bdi_kernel/userland/bdi_shell.c` - Fixed job_count overflow bug
- `bdi_kernel/tests/stress_tests.c` - Added missing stdint.h include

## ✅ Impact

These fixes ensure:
- No out-of-bounds memory access when background job limit is reached
- Proper compilation of stress tests
- System stability and safety improvements

## 🔗 Related

- Original implementation: PR #74
- Branch: `phase14-userland-integration`

---

**Note:** For GitHub App permissions and private repository access, please visit: [GitHub App Configuration](https://github.com/apps/abacusai/installations/select_target)