### PR TITLE
Fix: Remove self-include from C/c23_compat.h

### DIFF
--- a/C/c23_compat.h
+++ b/C/c23_compat.h
@@ -2,7 +2,6 @@
 // C23 Compatibility Header
 // Provides C23 features for compilers with partial support
 
-#include "c23_compat.h"
 #ifndef BDI_C23_COMPAT_H
 #define BDI_C23_COMPAT_H
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in `C/c23_compat.h` where the header file includes itself before the include guard, causing an infinite include loop during compilation.

## Bug Description

The header had a self-include directive on line 5, before the include guard:

```c
// BUGGY CODE:
#include "c23_compat.h"  // ❌ Self-include before guard
#ifndef BDI_C23_COMPAT_H
#define BDI_C23_COMPAT_H
```

This causes an infinite recursion during preprocessing:
1. File includes itself
2. Before the include guard can prevent re-inclusion
3. Leading to infinite loop and compilation failure

## Fix Applied

Removed the self-include line (line 5):

```c
// FIXED CODE:
#ifndef BDI_C23_COMPAT_H
#define BDI_C23_COMPAT_H
// ... rest of header
```

## Impact

- **Before**: Compilation fails with infinite include loop
- **After**: Header works correctly with proper include guard protection
- **Risk**: None - this is a pure bug fix with no functional changes

## Testing

- ✅ File compiles without errors
- ✅ Include guard now functions properly
- ✅ No other files affected (single-line deletion)

## Files Changed

- `C/c23_compat.h` - Removed self-include line

## Related

This bug was introduced in PR #80 (Phase 0 & 1: C23 Modernization) and prevents the C23 compatibility header from being used correctly in the codebase.