### PR TITLE
Fix P1 Bugs: Register Allocator Interval Growth & Scheduler Buffer Overflow

### DIFF
--- a/C/btl/btl_regalloc.c
+++ b/C/btl/btl_regalloc.c
@@ -88,8 +88,10 @@ int btl_regalloc_acquire(BTL_RegAllocator *allocator, uint32_t var_id,
             allocator->registers[i].live_start = start;
             allocator->registers[i].live_end = end;
             
-            // Add live interval
-            btl_regalloc_add_interval(allocator, var_id, start, end);
+            // NOTE: Do NOT add interval here during linear scan.
+            // Intervals should already exist before the scan begins.
+            // Adding intervals during scan causes the loop to process
+            // newly appended entries, leading to infinite growth.
             
             return (int)i;
         }

--- a/C/btl/btl_scheduler.c
+++ b/C/btl/btl_scheduler.c
@@ -10,6 +10,7 @@ struct BTL_Scheduler {
     BTL_DependencyGraph graph;
     uint32_t *schedule;
     size_t schedule_count;
+    size_t schedule_capacity;
     uint32_t critical_path_length;
 };
 
@@ -34,6 +35,7 @@ BTL_Scheduler* btl_scheduler_create(void) {
     }
     
     scheduler->schedule_count = 0;
+    scheduler->schedule_capacity = INITIAL_CAPACITY;
     scheduler->critical_path_length = 0;
     
     return scheduler;
@@ -248,6 +250,19 @@ bool btl_scheduler_schedule(BTL_Scheduler *scheduler) {
         }
         
         BTL_InstructionNode *node = ready[best_idx];
+        
+        // Expand schedule capacity if needed
+        if (scheduler->schedule_count >= scheduler->schedule_capacity) {
+            size_t new_capacity = scheduler->schedule_capacity * 2;
+            uint32_t *new_schedule = realloc(scheduler->schedule,
+                                             new_capacity * sizeof(uint32_t));
+            if (!new_schedule) {
+                free(ready);
+                return false;
+            }
+            scheduler->schedule = new_schedule;
+            scheduler->schedule_capacity = new_capacity;
+        }
         
         // Schedule the instruction
         node->scheduled = true;


### PR DESCRIPTION
## Summary
This PR fixes two critical P1 bugs in the Phase 2 implementation that were causing incorrect behavior and potential crashes.

## Bug Fixes

### Bug 1: Register Allocator - Interval Growth During Scan
**Location:** `C/btl/btl_regalloc.c`

**Problem:** The linear scan algorithm in `btl_regalloc_linear_scan()` calls `btl_regalloc_acquire()` for every interval. The `btl_regalloc_acquire()` function was calling `btl_regalloc_add_interval()` to append a new interval to the array. Because the linear scan loop iterates over `allocator->intervals` using `num_intervals` as the loop bound, each call to `btl_regalloc_acquire()` grew the array while it was being walked. This caused the loop to process the freshly appended copies, continuously extending `num_intervals` until the capacity cap was hit, making results (spill counts, assignment order) meaningless.

**Fix:** Removed the call to `btl_regalloc_add_interval()` from `btl_regalloc_acquire()`. The function now only marks the register as allocated without adding a new interval. Intervals should already exist before the linear scan begins.

### Bug 2: Scheduler - Fixed Schedule Buffer Overflow
**Location:** `C/btl/btl_scheduler.c`

**Problem:** The scheduler's `graph.nodes` array grows dynamically as instructions are added, but the `schedule` array was fixed at `INITIAL_CAPACITY` (256 entries) from construction and was never reallocated. When `btl_scheduler_schedule()` records the execution order, it blindly writes `schedule[schedule_count++]` for every node. Adding more than 256 instructions resulted in a heap overflow and corrupted schedules.

**Fix:** 
- Added `schedule_capacity` field to track the buffer size
- Implemented dynamic resizing before writing to the schedule array
- When `schedule_count >= schedule_capacity`, the buffer is reallocated with double the capacity
- This matches the behavior of the `graph.nodes` array

## Testing
- ✅ All existing tests pass successfully
- ✅ `test_btl_regalloc`: 4/4 tests passed
- ✅ `test_btl_scheduler`: 5/5 tests passed
- ✅ Build completes without errors

## Changes
- Modified `C/btl/btl_regalloc.c`: Removed interval addition from acquire function
- Modified `C/btl/btl_scheduler.c`: Added dynamic schedule buffer resizing

Both fixes are minimal, correct, and preserve existing functionality without introducing new issues.