### PR TITLE
fix: Critical bug fixes for Phase 4 (compilation and register allocation)

### DIFF
--- a/BDI_cpp/compiler/backend/regalloc/RegisterAllocator.cpp
+++ b/BDI_cpp/compiler/backend/regalloc/RegisterAllocator.cpp
@@ -122,11 +122,13 @@ std::unordered_map<SsaVariableID, uint32_t>
 RegisterAllocator::colorGraph(InterferenceGraph& graph, uint32_t num_colors) {
     std::unordered_map<SsaVariableID, uint32_t> coloring;
     
+    // Save original graph before simplify destroys it
+    InterferenceGraph original_graph = graph;
+    
     // Simplify phase
     auto stack = simplify(graph, num_colors);
     
     // Select phase
-    InterferenceGraph original_graph = graph; // Save original for select phase
     bool success = select(stack, original_graph, coloring, num_colors);
     
     if (!success) {

--- a/BDI_cpp/compiler/ssa/SsaConstruction.cpp
+++ b/BDI_cpp/compiler/ssa/SsaConstruction.cpp
@@ -39,6 +39,11 @@ SsaConstructor::computeDominance(const ControlFlowGraph& cfg) {
     return dom_info;
 }
 
+// Forward declaration
+BasicBlockID findCommonDominator(
+    BasicBlockID b1, BasicBlockID b2,
+    const std::unordered_map<BasicBlockID, DominanceInfo>& dom_info);
+
 void SsaConstructor::computeImmediateDominators(
     const ControlFlowGraph& cfg,
     std::unordered_map<BasicBlockID, DominanceInfo>& dom_info) {


### PR DESCRIPTION
## Critical Bug Fixes for Phase 4

This PR addresses two critical bugs discovered in Phase 4 that prevent correct compilation and execution:

### Bug 1: Missing Forward Declaration in SsaConstruction.cpp ✅
**Location**: `BDI_cpp/compiler/ssa/SsaConstruction.cpp`

**Issue**: The function `findCommonDominator` was called in `computeImmediateDominators` (line 75) before it was declared. C++ requires functions to be declared before use, causing compilation failure.

**Fix**: Added forward declaration for `findCommonDominator` before `computeImmediateDominators` function.

```cpp
// Forward declaration
BasicBlockID findCommonDominator(
    BasicBlockID b1, BasicBlockID b2,
    const std::unordered_map<BasicBlockID, DominanceInfo>& dom_info);
```

### Bug 2: Interference Graph Destroyed Before Use in RegisterAllocator.cpp ✅
**Location**: `BDI_cpp/compiler/backend/regalloc/RegisterAllocator.cpp`

**Issue**: In the `colorGraph` function, the code called `simplify(graph, num_colors)` which destructively removes nodes and edges from the interference graph, then attempted to copy the graph. The copy was empty, causing the `select` phase to see no interference relationships and potentially assign conflicting registers the same color.

**Fix**: Moved the graph copy operation to BEFORE the `simplify` call, preserving the full interference graph structure.

```cpp
// Save original graph before simplify destroys it
InterferenceGraph original_graph = graph;

// Simplify phase
auto stack = simplify(graph, num_colors);
```

### Impact
- **Bug 1**: Prevented compilation of SSA construction code
- **Bug 2**: Caused incorrect register allocation, leading to register conflicts and potential runtime errors

### Testing
- Both files now pass syntax validation
- Changes are minimal and surgical, affecting only the problematic areas
- No functional changes to algorithms, only ordering/declaration fixes

### Files Changed
- `BDI_cpp/compiler/ssa/SsaConstruction.cpp` (+5 lines)
- `BDI_cpp/compiler/backend/regalloc/RegisterAllocator.cpp` (+3 lines, -1 line)

---

**Commit**: e3a7d9b - "fix: resolve compilation and register allocation bugs in Phase 4"