### PR TITLE
fix(gc): Remove nursery compaction to prevent dangling references (P0)

### DIFF
--- a/C/vm/gc/generational_gc.c
+++ b/C/vm/gc/generational_gc.c
@@ -149,7 +149,7 @@ static void mark_young_generation(GenerationalGC* gc, GCRootSet* roots) {
 static void evacuate_young_generation(GenerationalGC* gc) {
     GenerationSpace* young = &gc->generations[GEN_YOUNG];
     GenObject* current = (GenObject*)young->start;
-    GenObject* compact_ptr = (GenObject*)young->start;  // Compaction destination
+    GenObject* last_survivor = NULL;  // Track the last survivor that stays in nursery
     
     while ((uint8_t*)current < (uint8_t*)young->allocation_ptr) {
         size_t total_size = current->header.base.size + sizeof(GenObjectHeader);
@@ -160,33 +160,43 @@ static void evacuate_young_generation(GenerationalGC* gc) {
             
             // Check if should promote
             if (generational_gc_should_promote(gc, current)) {
-                // Promote to old generation
+                // Promote to old generation (copies object to old gen)
                 generational_gc_promote(gc, current, GEN_OLD);
-                // Don't compact promoted objects - they're copied to old gen
             } else {
-                // Object stays in nursery - compact it
-                if (current != compact_ptr) {
-                    // Move object to compacted position
-                    memmove(compact_ptr, current, total_size);
-                }
-                // Advance compaction pointer
-                compact_ptr = (GenObject*)((uint8_t*)compact_ptr + total_size);
+                // Object stays in nursery - keep it in place (NO COMPACTION)
+                // 
+                // CRITICAL: We do NOT move this object because moving it would
+                // require updating ALL references pointing to it (from roots,
+                // remembered set, and other objects). Without reference updating,
+                // compaction creates dangling pointers that point to freed memory.
+                //
+                // This approach wastes space (fragmentation between survivors),
+                // but it's correct and safe. Future optimization can add proper
+                // compaction with full reference tracking and updating.
+                last_survivor = current;
             }
             
             current->header.base.marked = false;
         } else {
-            // Object is garbage - don't copy it, just account for freed space
+            // Object is garbage - free it
             generational_gc_free(gc, current);
         }
         
         current = (GenObject*)((uint8_t*)current + total_size);
     }
     
-    // Update allocation pointer to point after compacted survivors
-    young->allocation_ptr = compact_ptr;
-    
-    // Calculate actual used space (distance from start to compaction pointer)
-    young->used = (uint8_t*)compact_ptr - (uint8_t*)young->start;
+    // Set allocation pointer to the end of the last survivor
+    // This ensures we don't overwrite any surviving objects
+    if (last_survivor) {
+        size_t last_size = last_survivor->header.base.size + sizeof(GenObjectHeader);
+        young->allocation_ptr = (GenObject*)((uint8_t*)last_survivor + last_size);
+        young->used = (uint8_t*)young->allocation_ptr - (uint8_t*)young->start;
+    } else {
+        // No survivors remained in nursery (all promoted or garbage)
+        // Reset to start for fresh allocations
+        young->allocation_ptr = (GenObject*)young->start;
+        young->used = 0;
+    }
 }
 
 bool generational_gc_minor_collect(GenerationalGC* gc, GCRootSet* roots) {


### PR DESCRIPTION
## Critical Bug Fix: Compaction Without Reference Updating

This PR fixes a **critical P0 bug** introduced by the previous fix in PR #99.

### 🐛 The Problem

PR #99 fixed two bugs but introduced a new critical issue:

**Bug**: The fix compacted surviving nursery objects using `memmove()` but **did not update any references** pointing to those objects.

**Impact**:
- After compaction, all references (from roots, remembered set, other objects) still point to the OLD addresses
- Those old addresses are now free space and will be overwritten by the next allocation
- Result: **Dangling pointers, use-after-free, data corruption**

**Example**:
```
Before compaction:
[Obj A at 0x1000] [Obj B at 0x1100] [Dead] [Obj C at 0x1300]
Root points to 0x1100 (Obj B)

After compaction (buggy):
[Obj A at 0x1000] [Obj B at 0x1100] [Obj C at 0x1200] [Free space]
                   ^-- moved here
Root still points to 0x1100, but that's now Obj C!
```

### ✅ The Solution

**Remove compaction entirely** - keep survivors in their original positions.

**Why this works**:
- Survivors stay in place, so all existing references remain valid
- No reference updating needed
- Allocation pointer set to end of last survivor
- Simple, safe, and correct

**Trade-off**:
- Wastes some space (fragmentation between survivors)
- But prioritizes **correctness over efficiency**
- Future optimization can add proper compaction with full reference tracking

### 📝 Changes

**File Modified**: `C/vm/gc/generational_gc.c`

**Key Changes**:
1. Removed `memmove()` compaction code
2. Changed `compact_ptr` to `last_survivor` tracking
3. Survivors stay in their original positions
4. Added detailed comments explaining why compaction is dangerous
5. Set allocation pointer to end of last survivor

**Lines Changed**: +26, -16

### 🧪 Testing

- ✅ Code compiles successfully
- ✅ No syntax errors
- ✅ Logic verified against GC principles

### 🎯 Priority

**P0 (Critical)** - This bug causes:
- Dangling pointers
- Use-after-free vulnerabilities
- Data corruption
- Unpredictable crashes

### 🔍 Technical Details

**What the fix does**:
```c
// OLD (buggy): Compact survivors
if (current != compact_ptr) {
    memmove(compact_ptr, current, total_size);  // BUG: References not updated!
}
compact_ptr = (GenObject*)((uint8_t*)compact_ptr + total_size);

// NEW (correct): Keep survivors in place
last_survivor = current;  // Just track position, don't move
```

**After evacuation**:
```c
// Set allocation pointer to end of last survivor
if (last_survivor) {
    size_t last_size = last_survivor->header.base.size + sizeof(GenObjectHeader);
    young->allocation_ptr = (GenObject*)((uint8_t*)last_survivor + last_size);
    young->used = (uint8_t*)young->allocation_ptr - (uint8_t*)young->start;
} else {
    // No survivors, reset to start
    young->allocation_ptr = (GenObject*)young->start;
    young->used = 0;
}
```

### 📚 Future Work

For proper compaction with reference updating, we would need to:
1. Track all references to young objects (roots, remembered set, object fields)
2. After compaction, scan and update all references
3. Or implement Cheney-style copying with forwarding pointers

This is complex and should be done as a separate optimization, not as part of a critical bug fix.

---

**Ready for immediate review and merge** - This critical fix prevents data corruption in the Phase 7 VM garbage collection system.