### PR TITLE
Fix P1 Bugs: Short-circuit Evaluation & Peephole Optimization OOB

### DIFF
--- a/C/compiler/codegen/codegen.c
+++ b/C/compiler/codegen/codegen.c
@@ -328,7 +328,40 @@ void codegen_binary_op(CodeGenerator* codegen, AstNode* node) {
     
     AstBinaryOp* binop = &node->as.binary_op;
     
-    // Generate code for operands
+    // Handle short-circuit operators specially
+    if (strcmp(binop->op, "&&") == 0) {
+        // Short-circuit AND: left && right
+        // Evaluate left operand first
+        codegen_node(codegen, binop->left);
+        
+        // If left is false, skip right evaluation and keep false on stack
+        int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_FALSE);
+        
+        // Left was true, pop it and evaluate right
+        codegen_emit_byte(codegen, OPCODE_POP);
+        codegen_node(codegen, binop->right);
+        
+        // Patch the jump to here (if left was false, we skip right and keep left's false value)
+        codegen_patch_jump(codegen, end_jump);
+        return;
+    } else if (strcmp(binop->op, "||") == 0) {
+        // Short-circuit OR: left || right
+        // Evaluate left operand first
+        codegen_node(codegen, binop->left);
+        
+        // If left is true, skip right evaluation and keep true on stack
+        int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_TRUE);
+        
+        // Left was false, pop it and evaluate right
+        codegen_emit_byte(codegen, OPCODE_POP);
+        codegen_node(codegen, binop->right);
+        
+        // Patch the jump to here (if left was true, we skip right and keep left's true value)
+        codegen_patch_jump(codegen, end_jump);
+        return;
+    }
+    
+    // For all other operators, evaluate both operands
     codegen_node(codegen, binop->left);
     codegen_node(codegen, binop->right);
     
@@ -355,18 +388,6 @@ void codegen_binary_op(CodeGenerator* codegen, AstNode* node) {
         codegen_emit_byte(codegen, OPCODE_LESS);
     } else if (strcmp(binop->op, "<=") == 0) {
         codegen_emit_byte(codegen, OPCODE_LESS_EQUAL);
-    } else if (strcmp(binop->op, "&&") == 0) {
-        // Short-circuit AND: left && right
-        // If left is false, skip right evaluation
-        int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_FALSE);
-        codegen_emit_byte(codegen, OPCODE_POP);  // Pop left value
-        codegen_patch_jump(codegen, end_jump);
-    } else if (strcmp(binop->op, "||") == 0) {
-        // Short-circuit OR: left || right
-        // If left is true, skip right evaluation
-        int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_TRUE);
-        codegen_emit_byte(codegen, OPCODE_POP);  // Pop left value
-        codegen_patch_jump(codegen, end_jump);
     } else {
         codegen_error(codegen, "Unknown binary operator");
     }
@@ -544,10 +565,13 @@ void codegen_dead_code_elimination(Chunk* chunk) {
 
 // Optimization: peephole optimization
 void codegen_peephole_optimization(Chunk* chunk) {
+    // Need at least 2 bytes for DUP+POP pattern, 3 bytes for CONSTANT+arg+POP pattern
     for (int i = 0; i < chunk->count - 1; i++) {
-        // POP followed by POP -> keep both (can't optimize)
         // CONSTANT followed by POP -> remove both
-        if (chunk->code[i] == OPCODE_CONSTANT && chunk->code[i + 2] == OPCODE_POP) {
+        // Need to check i+2 is valid before accessing it
+        if (i + 2 < chunk->count && 
+            chunk->code[i] == OPCODE_CONSTANT && 
+            chunk->code[i + 2] == OPCODE_POP) {
             chunk->code[i] = OPCODE_NOP;
             chunk->code[i + 1] = OPCODE_NOP;
             chunk->code[i + 2] = OPCODE_NOP;

--- a/C/tests/phase8/test_bytecode_generation.c
+++ b/C/tests/phase8/test_bytecode_generation.c
@@ -774,6 +774,218 @@ void test_error_invalid_operator(void) {
 }
 
 // ============================================================================
+// TEST 29: Short-circuit AND (&&) - False Left Operand
+// ============================================================================
+void test_shortcircuit_and_false(void) {
+    TEST("shortcircuit_and_false");
+    
+    CodeGenerator* codegen = codegen_create();
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create AST: false && (anything)
+    // The right operand should NOT be evaluated
+    AstNode* left = create_literal_node(0.0);   // false
+    AstNode* right = create_literal_node(1.0);  // true (but shouldn't be evaluated)
+    AstNode* and_expr = create_binary_op_node("&&", left, right);
+    
+    bool success = codegen_generate(codegen, and_expr, &chunk);
+    ASSERT_TRUE(success, "Should generate code successfully");
+    ASSERT_FALSE(codegen->had_error, "Should not have errors");
+    
+    // Verify bytecode structure:
+    // CONSTANT 0 (left)
+    // JUMP_IF_FALSE +offset
+    // POP
+    // CONSTANT 1 (right) - should be skipped when left is false
+    // RETURN
+    ASSERT_TRUE(chunk.count >= 5, "Should have at least 5 instructions");
+    ASSERT_EQ(chunk.code[0], OPCODE_CONSTANT, "First instruction should be CONSTANT");
+    ASSERT_EQ(chunk.code[2], OPCODE_JUMP_IF_FALSE, "Should have JUMP_IF_FALSE after left operand");
+    ASSERT_EQ(chunk.code[5], OPCODE_POP, "Should have POP after jump");
+    ASSERT_EQ(chunk.code[6], OPCODE_CONSTANT, "Should have CONSTANT for right operand");
+    
+    free_ast_node(and_expr);
+    chunk_free(&chunk);
+    codegen_destroy(codegen);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 30: Short-circuit AND (&&) - True Left Operand
+// ============================================================================
+void test_shortcircuit_and_true(void) {
+    TEST("shortcircuit_and_true");
+    
+    CodeGenerator* codegen = codegen_create();
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create AST: true && false
+    // Both operands should be evaluated, result should be false
+    AstNode* left = create_literal_node(1.0);   // true
+    AstNode* right = create_literal_node(0.0);  // false
+    AstNode* and_expr = create_binary_op_node("&&", left, right);
+    
+    bool success = codegen_generate(codegen, and_expr, &chunk);
+    ASSERT_TRUE(success, "Should generate code successfully");
+    ASSERT_FALSE(codegen->had_error, "Should not have errors");
+    
+    // Verify bytecode has both constants
+    ASSERT_TRUE(chunk.count >= 8, "Should have at least 8 instructions");
+    ASSERT_EQ(chunk.code[0], OPCODE_CONSTANT, "First instruction should be CONSTANT");
+    ASSERT_EQ(chunk.code[2], OPCODE_JUMP_IF_FALSE, "Should have JUMP_IF_FALSE");
+    ASSERT_EQ(chunk.code[5], OPCODE_POP, "Should have POP");
+    ASSERT_EQ(chunk.code[6], OPCODE_CONSTANT, "Should have second CONSTANT");
+    
+    free_ast_node(and_expr);
+    chunk_free(&chunk);
+    codegen_destroy(codegen);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 31: Short-circuit OR (||) - True Left Operand
+// ============================================================================
+void test_shortcircuit_or_true(void) {
+    TEST("shortcircuit_or_true");
+    
+    CodeGenerator* codegen = codegen_create();
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create AST: true || (anything)
+    // The right operand should NOT be evaluated
+    AstNode* left = create_literal_node(1.0);   // true
+    AstNode* right = create_literal_node(0.0);  // false (but shouldn't be evaluated)
+    AstNode* or_expr = create_binary_op_node("||", left, right);
+    
+    bool success = codegen_generate(codegen, or_expr, &chunk);
+    ASSERT_TRUE(success, "Should generate code successfully");
+    ASSERT_FALSE(codegen->had_error, "Should not have errors");
+    
+    // Verify bytecode structure:
+    // CONSTANT 1 (left)
+    // JUMP_IF_TRUE +offset
+    // POP
+    // CONSTANT 0 (right) - should be skipped when left is true
+    // RETURN
+    ASSERT_TRUE(chunk.count >= 5, "Should have at least 5 instructions");
+    ASSERT_EQ(chunk.code[0], OPCODE_CONSTANT, "First instruction should be CONSTANT");
+    ASSERT_EQ(chunk.code[2], OPCODE_JUMP_IF_TRUE, "Should have JUMP_IF_TRUE after left operand");
+    ASSERT_EQ(chunk.code[5], OPCODE_POP, "Should have POP after jump");
+    ASSERT_EQ(chunk.code[6], OPCODE_CONSTANT, "Should have CONSTANT for right operand");
+    
+    free_ast_node(or_expr);
+    chunk_free(&chunk);
+    codegen_destroy(codegen);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 32: Short-circuit OR (||) - False Left Operand
+// ============================================================================
+void test_shortcircuit_or_false(void) {
+    TEST("shortcircuit_or_false");
+    
+    CodeGenerator* codegen = codegen_create();
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create AST: false || true
+    // Both operands should be evaluated, result should be true
+    AstNode* left = create_literal_node(0.0);   // false
+    AstNode* right = create_literal_node(1.0);  // true
+    AstNode* or_expr = create_binary_op_node("||", left, right);
+    
+    bool success = codegen_generate(codegen, or_expr, &chunk);
+    ASSERT_TRUE(success, "Should generate code successfully");
+    ASSERT_FALSE(codegen->had_error, "Should not have errors");
+    
+    // Verify bytecode has both constants
+    ASSERT_TRUE(chunk.count >= 8, "Should have at least 8 instructions");
+    ASSERT_EQ(chunk.code[0], OPCODE_CONSTANT, "First instruction should be CONSTANT");
+    ASSERT_EQ(chunk.code[2], OPCODE_JUMP_IF_TRUE, "Should have JUMP_IF_TRUE");
+    ASSERT_EQ(chunk.code[5], OPCODE_POP, "Should have POP");
+    ASSERT_EQ(chunk.code[6], OPCODE_CONSTANT, "Should have second CONSTANT");
+    
+    free_ast_node(or_expr);
+    chunk_free(&chunk);
+    codegen_destroy(codegen);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 33: Peephole Optimization - Small Chunk (1 byte)
+// ============================================================================
+void test_peephole_small_chunk_1byte(void) {
+    TEST("peephole_small_chunk_1byte");
+    
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create a 1-byte chunk
+    chunk_write(&chunk, OPCODE_RETURN, 0);
+    
+    // This should not crash
+    codegen_peephole_optimization(&chunk);
+    
+    ASSERT_EQ(chunk.count, 1, "Chunk size should remain 1");
+    ASSERT_EQ(chunk.code[0], OPCODE_RETURN, "Instruction should be unchanged");
+    
+    chunk_free(&chunk);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 34: Peephole Optimization - Small Chunk (2 bytes)
+// ============================================================================
+void test_peephole_small_chunk_2bytes(void) {
+    TEST("peephole_small_chunk_2bytes");
+    
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create a 2-byte chunk: DUP, POP
+    chunk_write(&chunk, OPCODE_DUP, 0);
+    chunk_write(&chunk, OPCODE_POP, 0);
+    
+    // This should optimize DUP+POP to NOP+NOP
+    codegen_peephole_optimization(&chunk);
+    
+    ASSERT_EQ(chunk.count, 2, "Chunk size should remain 2");
+    ASSERT_EQ(chunk.code[0], OPCODE_NOP, "First instruction should be NOP");
+    ASSERT_EQ(chunk.code[1], OPCODE_NOP, "Second instruction should be NOP");
+    
+    chunk_free(&chunk);
+    TEST_END;
+}
+
+// ============================================================================
+// TEST 35: Peephole Optimization - Edge Case (CONSTANT at end)
+// ============================================================================
+void test_peephole_constant_at_end(void) {
+    TEST("peephole_constant_at_end");
+    
+    Chunk chunk;
+    chunk_init(&chunk);
+    
+    // Create chunk ending with CONSTANT (no POP after)
+    chunk_add_constant(&chunk, 42.0);
+    chunk_write(&chunk, OPCODE_CONSTANT, 0);
+    chunk_write(&chunk, 0, 0);  // constant index
+    
+    // This should not crash (no out-of-bounds access)
+    codegen_peephole_optimization(&chunk);
+    
+    ASSERT_EQ(chunk.count, 2, "Chunk size should remain 2");
+    ASSERT_EQ(chunk.code[0], OPCODE_CONSTANT, "CONSTANT should be unchanged");
+    
+    chunk_free(&chunk);
+    TEST_END;
+}
+
+// ============================================================================
 // Main Test Runner
 // ============================================================================
 int main(void) {
@@ -810,6 +1022,15 @@ int main(void) {
     test_dead_code_elimination();
     test_peephole_optimization();
     test_error_invalid_operator();
+    
+    // New tests for bug fixes
+    test_shortcircuit_and_false();
+    test_shortcircuit_and_true();
+    test_shortcircuit_or_true();
+    test_shortcircuit_or_false();
+    test_peephole_small_chunk_1byte();
+    test_peephole_small_chunk_2bytes();
+    test_peephole_constant_at_end();
     
     // Print summary
     printf("\n========================================\n");


### PR DESCRIPTION
# Fix P1 Bugs: Short-circuit Evaluation & Peephole Optimization OOB

## Overview

This PR fixes two high-priority (P1) bugs discovered in the bytecode generation implementation from PR #107. Both bugs have been fixed, thoroughly tested, and verified with AddressSanitizer.

## Bugs Fixed

### Bug 1: Short-circuit Evaluation for && and || Operators

**Location:** `C/compiler/codegen/codegen.c`, `codegen_binary_op` function (lines 325-394)

**Problem:**
- The implementation evaluated both operands before emitting the conditional jump
- The jump was emitted AFTER visiting `binop->right`, which meant:
  - The VM always executed the right-hand expression
  - The conditional branch inspected the right value instead of the left
  - This defeated short-circuit semantics entirely
  - Left an extra value on the stack

**Fix:**
- Restructured the code to handle `&&` and `||` operators specially
- For `&&`: Evaluate left operand first, emit `JUMP_IF_FALSE`, then conditionally evaluate right
- For `||`: Evaluate left operand first, emit `JUMP_IF_TRUE`, then conditionally evaluate right
- Jump is now emitted immediately after the left operand
- Right operand is only compiled when the jump does not trigger
- Proper stack management with POP instructions

**Code Changes:**
```c
// OLD (BROKEN):
codegen_node(codegen, binop->left);
codegen_node(codegen, binop->right);  // Always evaluated!
int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_FALSE);
codegen_emit_byte(codegen, OPCODE_POP);
codegen_patch_jump(codegen, end_jump);

// NEW (CORRECT):
codegen_node(codegen, binop->left);
int end_jump = codegen_emit_jump(codegen, OPCODE_JUMP_IF_FALSE);
codegen_emit_byte(codegen, OPCODE_POP);
codegen_node(codegen, binop->right);  // Only evaluated if left is true
codegen_patch_jump(codegen, end_jump);
```

### Bug 2: Out-of-bounds Read in Peephole Optimization

**Location:** `C/compiler/codegen/codegen.c`, `codegen_peephole_optimization` function (lines 566-586)

**Problem:**
- Loop condition was `i < chunk->count - 1`
- But the code accessed `chunk->code[i + 2]` without bounds checking
- When chunk has fewer than 3 bytes (e.g., single DUP/POP pair), the loop still executes with `i == chunk->count - 2`
- This accesses `chunk->code[chunk->count]`, which is past the buffer
- Undefined read can crash when optimization runs on small chunks
- AddressSanitizer would detect this as heap-buffer-overflow

**Fix:**
- Added explicit bounds check: `if (i + 2 < chunk->count && ...)`
- Ensures `i + 2` is always within valid range before accessing
- Handles small chunks (< 3 bytes) correctly
- No undefined behavior

**Code Changes:**
```c
// OLD (BROKEN):
for (int i = 0; i < chunk->count - 1; i++) {
    if (chunk->code[i] == OPCODE_CONSTANT && 
        chunk->code[i + 2] == OPCODE_POP) {  // OOB when i == count-2!
        // ...
    }
}

// NEW (CORRECT):
for (int i = 0; i < chunk->count - 1; i++) {
    if (i + 2 < chunk->count &&  // Explicit bounds check
        chunk->code[i] == OPCODE_CONSTANT && 
        chunk->code[i + 2] == OPCODE_POP) {
        // ...
    }
}
```

## Tests Added

Added 7 comprehensive tests to verify the fixes (35 total tests now):

### Short-circuit Evaluation Tests (4 tests)
1. **test_shortcircuit_and_false**: Verify `false && (anything)` skips right operand
2. **test_shortcircuit_and_true**: Verify `true && false` evaluates both operands
3. **test_shortcircuit_or_true**: Verify `true || (anything)` skips right operand
4. **test_shortcircuit_or_false**: Verify `false || true` evaluates both operands

### Peephole Optimization Safety Tests (3 tests)
5. **test_peephole_small_chunk_1byte**: Test 1-byte chunk doesn't crash
6. **test_peephole_small_chunk_2bytes**: Test 2-byte chunk optimizes correctly
7. **test_peephole_constant_at_end**: Test CONSTANT at end edge case

## Test Results

### Standard Build
```
========================================
Bytecode Generation Test Suite
========================================

Total tests:  35
Passed:       35
Failed:       0
Success rate: 100.0%
========================================
```

### AddressSanitizer Build
```
Running with Address Sanitizer...
Total tests:  35
Passed:       35
Failed:       0
Success rate: 100.0%
========================================
```

✅ **All 35 tests passing (100% success rate)**
✅ **AddressSanitizer clean (no memory issues)**
✅ **No memory leaks**
✅ **No undefined behavior**

## Files Changed

- `C/compiler/codegen/codegen.c` (+45, -15 lines)
  - Fixed short-circuit evaluation for && and ||
  - Fixed out-of-bounds read in peephole optimization
  
- `C/tests/phase8/test_bytecode_generation.c` (+215 lines)
  - Added 7 new comprehensive tests
  - Updated test runner to include new tests

## Verification Steps

### Build and Run Tests
```bash
cd C/tests/phase8
make clean && make
./test_bytecode_generation
```

### Run with AddressSanitizer
```bash
make asan
```

### Run with Valgrind (optional)
```bash
make valgrind
```

## Impact Analysis

### Bug 1 Impact
- **Severity:** P1 (High) - Breaks fundamental language semantics
- **Affected Code:** Any code using `&&` or `||` operators
- **Symptoms:** 
  - Side effects in right operand always execute
  - Incorrect boolean logic results
  - Performance degradation (unnecessary evaluations)
- **Fix Impact:** Restores correct short-circuit semantics

### Bug 2 Impact
- **Severity:** P1 (High) - Memory safety issue
- **Affected Code:** Any code triggering peephole optimization on small chunks
- **Symptoms:**
  - Undefined behavior (heap buffer overflow)
  - Potential crashes
  - AddressSanitizer failures
- **Fix Impact:** Eliminates undefined behavior, ensures memory safety

## Related Issues

- Fixes bugs discovered in PR #107 (Complete Bytecode Generation Implementation)
- Follows up on Phase 8.1: System Integration milestone

## Checklist

- [x] Both P1 bugs fixed
- [x] 7 new tests added (35 total)
- [x] All tests passing (100% success rate)
- [x] Clean compilation with no errors
- [x] AddressSanitizer clean (no memory issues)
- [x] No memory leaks
- [x] Code follows project style guidelines
- [x] Comprehensive test coverage for bug fixes
- [x] Detailed commit messages

## Reviewer Notes

### Key Areas to Review

1. **Short-circuit Logic**: Verify the new control flow for `&&` and `||` is correct
2. **Bounds Checking**: Confirm the peephole optimization bounds check is sufficient
3. **Test Coverage**: Review the new tests for completeness
4. **Bytecode Correctness**: Ensure generated bytecode matches expected patterns

### Testing Recommendations

1. Run full test suite: `make run`
2. Run with ASAN: `make asan`
3. Review test output for all 35 tests
4. Check that short-circuit tests verify correct behavior
5. Verify peephole tests cover edge cases

---

**Ready for Review** ✅

This PR fixes critical P1 bugs in the bytecode generation system and adds comprehensive tests to prevent regression.