### PR TITLE
Fix P1 Bug: Replace GNU Statement Expression with Standard C (C2x Compliance)

### DIFF
--- a/C/tests/phase8/test_result_capture.c
+++ b/C/tests/phase8/test_result_capture.c
@@ -44,13 +44,14 @@ static int tests_failed = 0;
     }
 
 // Helper to run pipeline with result capture enabled
-#define RUN_PIPELINE(source) \
-    ({ \
-        PipelineConfig config = pipeline_default_config(); \
-        config.enable_gc = false; \
-        config.enable_optimization = false; \
-        pipeline_run_with_config(source, config); \
-    })
+static inline PipelineResult run_pipeline_helper(const char* source) {
+    PipelineConfig config = pipeline_default_config();
+    config.enable_gc = false;
+    config.enable_optimization = false;
+    return pipeline_run_with_config(source, config);
+}
+
+#define RUN_PIPELINE(source) run_pipeline_helper(source)
 
 // ============================================================================
 // RESULT CAPTURE TESTS


### PR DESCRIPTION
## Problem

The `RUN_PIPELINE` macro in `C/tests/phase8/test_result_capture.c` used a GNU statement expression `({ ... })` which is not standard C. This caused compilation failures when building with strict C standards (`-std=c2x -Wpedantic -Werror`).

**Build Error:**
- ISO C forbids braced-groups within expressions
- Breaks compilation on any strictly conforming C compiler
- Violates project's C2x standard compliance requirements

## Solution

Replaced the GNU statement expression with a standard C inline function:

**Before (GNU Extension):**
```c
#define RUN_PIPELINE(source) \
    ({ \
        PipelineConfig config = pipeline_default_config(); \
        config.enable_gc = false; \
        config.enable_optimization = false; \
        pipeline_run_with_config(source, config); \
    })
```

**After (Standard C):**
```c
static inline PipelineResult run_pipeline_helper(const char* source) {
    PipelineConfig config = pipeline_default_config();
    config.enable_gc = false;
    config.enable_optimization = false;
    return pipeline_run_with_config(source, config);
}

#define RUN_PIPELINE(source) run_pipeline_helper(source)
```

## Verification

✅ **Compilation**: Builds cleanly with `-std=c2x -Wpedantic -Werror`  
✅ **Functionality**: All tests maintain identical behavior (14/15 pass)  
✅ **Standards**: No GNU extensions, fully C2x compliant  
✅ **Compatibility**: Works on all standard C compilers  

## Test Results

```
=== Test Summary ===
Total tests: 15
Passed: 14
Failed: 1
```

Same results as before - the one failing test is unrelated to this fix.

## Impact

- ✅ Fixes P1 build failure blocking Phase 8.1 completion
- ✅ Ensures C2x standard compliance across the project
- ✅ Enables compilation on all standard C toolchains
- ✅ Maintains exact same test functionality
- ✅ Clean, readable standard C code

This fix resolves the critical build issue while maintaining all existing functionality.