### PR TITLE
Fix 5 Critical Compilation Bugs in JIT Test Suite (P0/P1)

### DIFF
--- a/C/tests/phase8/test_jit_benchmarks.c
+++ b/C/tests/phase8/test_jit_benchmarks.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -59,30 +60,30 @@ static Chunk* create_arithmetic_benchmark_chunk(void) {
     // Where a=10, b=20, c=3, d=100, e=4, f=5
     // Result: ((10+20)*3) - ((100/4)+5) = (30*3) - (25+5) = 90 - 30 = 60
     
-    int const_idx = chunk_add_constant(chunk, 10.0);
+    int const1_idx = chunk_add_constant(chunk, 10.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
-    int const_idx = chunk_add_constant(chunk, 20.0);
+    chunk_write(chunk, const1_idx, 1);
+    int const2_idx = chunk_add_constant(chunk, 20.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const2_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     
-    int const_idx = chunk_add_constant(chunk, 3.0);
+    int const3_idx = chunk_add_constant(chunk, 3.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const3_idx, 1);
     chunk_write(chunk, OP_MULTIPLY, 1);
     
-    int const_idx = chunk_add_constant(chunk, 100.0);
+    int const4_idx = chunk_add_constant(chunk, 100.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
-    int const_idx = chunk_add_constant(chunk, 4.0);
+    chunk_write(chunk, const4_idx, 1);
+    int const5_idx = chunk_add_constant(chunk, 4.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const5_idx, 1);
     chunk_write(chunk, OP_DIVIDE, 1);
     
-    int const_idx = chunk_add_constant(chunk, 5.0);
+    int const6_idx = chunk_add_constant(chunk, 5.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const6_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     
     chunk_write(chunk, OP_SUBTRACT, 1);
@@ -99,8 +100,8 @@ static Chunk* create_nested_benchmark_chunk(void) {
     // Deeply nested computation
     for (int i = 1; i <= 8; i++) {
         int const_idx = chunk_add_constant(chunk, (double)i);
-    chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+        chunk_write(chunk, OP_CONSTANT, 1);
+        chunk_write(chunk, const_idx, 1);
         if (i > 1) {
             if (i % 2 == 0) {
                 chunk_write(chunk, OP_ADD, 1);
@@ -181,12 +182,12 @@ void benchmark_simple_arithmetic(void) {
     
     Chunk* chunk = (Chunk*)malloc(sizeof(Chunk));
     chunk_init(chunk);
-    int const_idx = chunk_add_constant(chunk, 42.0);
+    int const1_idx = chunk_add_constant(chunk, 42.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
-    int const_idx = chunk_add_constant(chunk, 13.0);
+    chunk_write(chunk, const1_idx, 1);
+    int const2_idx = chunk_add_constant(chunk, 13.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const2_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     chunk_write(chunk, OP_RETURN, 1);
     
@@ -387,8 +388,11 @@ void benchmark_hot_path_detection(void) {
     ASSERT(vm != NULL);
     
     Chunk* hot_chunk = create_arithmetic_benchmark_chunk();
-    Chunk* cold_chunk = chunk_create();
-    chunk_write_constant(cold_chunk, 1.0, 1);
+    Chunk* cold_chunk = (Chunk*)malloc(sizeof(Chunk));
+    chunk_init(cold_chunk);
+    int const_idx = chunk_add_constant(cold_chunk, 1.0);
+    chunk_write(cold_chunk, OP_CONSTANT, 1);
+    chunk_write(cold_chunk, const_idx, 1);
     chunk_write(cold_chunk, OP_RETURN, 1);
     
     const int hot_executions = 1000;
@@ -497,3 +501,4 @@ int main(void) {
         return 1;
     }
 }
+

--- a/C/tests/phase8/test_jit_correctness.c
+++ b/C/tests/phase8/test_jit_correctness.c
@@ -1,4 +1,5 @@
 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,7 +47,7 @@ static Chunk* create_arithmetic_chunk(double a, double b, uint8_t op) {
     chunk_write(chunk, const1, 1);
     int const2 = chunk_add_constant(chunk, b);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
+    chunk_write(chunk, const2, 1);
     chunk_write(chunk, op, 1);
     chunk_write(chunk, OP_RETURN, 1);
     
@@ -61,25 +62,25 @@ static Chunk* create_nested_chunk(void) {
     // Expression: ((2 + 3) * 4) - (10 / 2)
     // = (5 * 4) - 5 = 20 - 5 = 15
     
-    int const_idx = chunk_add_constant(chunk, 2.0);
+    int const1_idx = chunk_add_constant(chunk, 2.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
-    int const_idx = chunk_add_constant(chunk, 3.0);
+    chunk_write(chunk, const1_idx, 1);
+    int const2_idx = chunk_add_constant(chunk, 3.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
+    chunk_write(chunk, const2_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     
-    int const_idx = chunk_add_constant(chunk, 4.0);
+    int const3_idx = chunk_add_constant(chunk, 4.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
+    chunk_write(chunk, const3_idx, 1);
     chunk_write(chunk, OP_MULTIPLY, 1);
     
-    int const_idx = chunk_add_constant(chunk, 10.0);
+    int const4_idx = chunk_add_constant(chunk, 10.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
-    int const_idx = chunk_add_constant(chunk, 2.0);
+    chunk_write(chunk, const4_idx, 1);
+    int const5_idx = chunk_add_constant(chunk, 2.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
+    chunk_write(chunk, const5_idx, 1);
     chunk_write(chunk, OP_DIVIDE, 1);
     
     chunk_write(chunk, OP_SUBTRACT, 1);
@@ -174,7 +175,7 @@ void test_jit_negation_correctness(void) {
     chunk_init(chunk);
     int const_idx = chunk_add_constant(chunk, 42.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const1, 1);
+    chunk_write(chunk, const_idx, 1);
     chunk_write(chunk, OP_NEGATE, 1);
     chunk_write(chunk, OP_RETURN, 1);
     
@@ -322,3 +323,4 @@ int main(void) {
         return 1;
     }
 }
+

--- a/C/tests/phase8/test_jit_integration.c
+++ b/C/tests/phase8/test_jit_integration.c
@@ -1,4 +1,5 @@
 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,12 +40,12 @@ static Chunk* create_simple_chunk(void) {
     Chunk* chunk = (Chunk*)malloc(sizeof(Chunk));
     chunk_init(chunk);
     
-    int const_idx = chunk_add_constant(chunk, 10.0);
+    int const1_idx = chunk_add_constant(chunk, 10.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
-    int const_idx = chunk_add_constant(chunk, 5.0);
+    chunk_write(chunk, const1_idx, 1);
+    int const2_idx = chunk_add_constant(chunk, 5.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const2_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     chunk_write(chunk, OP_RETURN, 1);
     
@@ -437,3 +438,4 @@ int main(void) {
         return 1;
     }
 }
+

--- a/C/tests/phase8/test_jit_stress.c
+++ b/C/tests/phase8/test_jit_stress.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,18 +40,18 @@ static Chunk* create_large_computation_chunk(void) {
     chunk_init(chunk);
     
     // Large nested computation: ((((1+2)*3)+4)*5)+6)*7)+8)*9)+10
-    int const_idx = chunk_add_constant(chunk, 1.0);
+    int const1_idx = chunk_add_constant(chunk, 1.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
-    int const_idx = chunk_add_constant(chunk, 2.0);
+    chunk_write(chunk, const1_idx, 1);
+    int const2_idx = chunk_add_constant(chunk, 2.0);
     chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+    chunk_write(chunk, const2_idx, 1);
     chunk_write(chunk, OP_ADD, 1);
     
     for (int i = 3; i <= 10; i++) {
         int const_idx = chunk_add_constant(chunk, (double)i);
-    chunk_write(chunk, OP_CONSTANT, 1);
-    chunk_write(chunk, const_idx, 1);
+        chunk_write(chunk, OP_CONSTANT, 1);
+        chunk_write(chunk, const_idx, 1);
         if (i % 2 == 1) {
             chunk_write(chunk, OP_MULTIPLY, 1);
         } else {
@@ -67,14 +68,19 @@ static Chunk** create_multiple_chunks(int count) {
     Chunk** chunks = (Chunk**)malloc(count * sizeof(Chunk*));
     
     for (int i = 0; i < count; i++) {
-        chunks[i] = chunk_create();
+        chunks[i] = (Chunk*)malloc(sizeof(Chunk));
+        chunk_init(chunks[i]);
         
         // Create different expressions for each chunk
         double a = (double)(i + 1);
         double b = (double)(i + 2);
         
-        chunk_write_constant(chunks[i], a, 1);
-        chunk_write_constant(chunks[i], b, 1);
+        int const1_idx = chunk_add_constant(chunks[i], a);
+        chunk_write(chunks[i], OP_CONSTANT, 1);
+        chunk_write(chunks[i], const1_idx, 1);
+        int const2_idx = chunk_add_constant(chunks[i], b);
+        chunk_write(chunks[i], OP_CONSTANT, 1);
+        chunk_write(chunks[i], const2_idx, 1);
         
         switch (i % 4) {
             case 0: chunk_write(chunks[i], OP_ADD, 1); break;
@@ -300,7 +306,8 @@ static void* thread_execute_function(void* arg) {
         }
         
         // Small delay to increase contention
-        usleep(1);
+        struct timespec ts = {0, 1000}; // 1 microsecond
+        nanosleep(&ts, NULL);
     }
     
     return NULL;
@@ -459,3 +466,4 @@ int main(void) {
         return 1;
     }
 }
+


### PR DESCRIPTION
## Summary

This PR fixes 5 critical compilation bugs (P0/P1 priority) in the JIT test suite that were preventing the test files from building and blocking verification of the VM-JIT integration.

## Bugs Fixed

### 🔴 Bug 1 (P0): Variable Redeclarations in `test_jit_correctness.c`
- **Issue**: Multiple `const_idx` declarations in same scope + undefined `const1` references
- **Fix**: Use unique variable names (`const1_idx`, `const2_idx`, etc.)
- **Impact**: `create_nested_chunk()` and `create_arithmetic_chunk()` now compile cleanly

### 🟡 Bug 2 (P1): Wrong Constants in Arithmetic Operations
- **Issue**: `create_arithmetic_chunk()` always used `const1` for both operands
- **Fix**: Correctly use `const2` for second operand
- **Impact**: Arithmetic tests now actually test `a op b` instead of `a op a`

### 🔴 Bug 3 (P0): Variable Redeclarations in `test_jit_integration.c`
- **Issue**: Redeclared `const_idx` in `create_simple_chunk()`
- **Fix**: Use unique names (`const1_idx`, `const2_idx`)
- **Impact**: Integration tests now compile without errors

### 🔴 Bug 4 (P0): Multiple Redeclarations in `test_jit_benchmarks.c`
- **Issue**: Multiple `const_idx` redeclarations throughout benchmark functions
- **Fix**: Use unique variable names for all constant declarations
- **Additional**: Added `_POSIX_C_SOURCE` for `clock_gettime()` support
- **Impact**: All benchmark tests now compile cleanly

### 🔴 Bug 5 (P0): Nonexistent Chunk API in `test_jit_stress.c`
- **Issue**: Used `chunk_create()` and `chunk_write_constant()` which don't exist
- **Fix**: Replace with proper `malloc()` + `chunk_init()` and `chunk_add_constant()` + `chunk_write()`
- **Additional**: Added `_POSIX_C_SOURCE` and replaced `usleep()` with `nanosleep()`
- **Impact**: Stress tests now use correct chunk API

## Verification

All test files now compile cleanly with strict C standards:

```bash
gcc -std=c2x -Wpedantic -Werror -I../../ -c test_jit_correctness.c ✅
gcc -std=c2x -Wpedantic -Werror -I../../ -c test_jit_integration.c ✅
gcc -std=c2x -Wpedantic -Werror -I../../ -c test_jit_benchmarks.c ✅
gcc -std=c2x -Wpedantic -Werror -I../../ -c test_jit_stress.c ✅
```

## Files Changed

- `C/tests/phase8/test_jit_correctness.c` - Fixed variable redeclarations and arithmetic logic
- `C/tests/phase8/test_jit_integration.c` - Fixed variable redeclarations  
- `C/tests/phase8/test_jit_benchmarks.c` - Fixed redeclarations + added POSIX support
- `C/tests/phase8/test_jit_stress.c` - Fixed chunk API usage + added POSIX support

## Impact

✅ **Before**: JIT test suite failed to compile, blocking PR #114 verification  
✅ **After**: All JIT test files compile cleanly, enabling full test suite execution

This unblocks the VM-JIT integration verification and allows the comprehensive test suite (54+ tests across 6 categories) to run properly.

## Testing

- [x] All test files compile without errors or warnings
- [x] No variable redeclaration errors
- [x] Correct chunk API usage throughout
- [x] Arithmetic operations use correct operands
- [x] POSIX compliance for time functions

Ready for merge into `feature/vm-jit-integration` branch.