### PR TITLE
Fix missing headers in tty.h and hpet.c (Bug fixes for PR #150)

### DIFF
--- a/bdi_kernel/drivers/timer/hpet.c
+++ b/bdi_kernel/drivers/timer/hpet.c
@@ -1,4 +1,5 @@
 
+#include <stdlib.h>       // For calloc/free
 #include "../../include/bdi/drivers/hpet.h"
 #include <string.h>
 #include <stdio.h>

--- a/bdi_kernel/include/bdi/drivers/tty.h
+++ b/bdi_kernel/include/bdi/drivers/tty.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <termios.h>      // For struct termios
+#include <sys/types.h>    // For ssize_t
 
 /* TTY buffer sizes */
 #define TTY_BUF_SIZE        4096


### PR DESCRIPTION
# Bug Fixes for Critical Subsystems (PR #150)

## Overview
This PR fixes two compilation bugs introduced in PR #150 that would prevent the kernel drivers from compiling.

## Bugs Fixed

### ✅ Bug 1: Missing headers in tty.h
**Location:** `bdi_kernel/include/bdi/drivers/tty.h`

**Problem:** The TTY header uses `struct termios` and `ssize_t` but doesn't include the required headers.

**Fix:** Added missing includes:
```c
#include <termios.h>      // For struct termios
#include <sys/types.h>    // For ssize_t
```

**Impact:** Every file that includes tty.h would fail to compile with incomplete-type and unknown-type errors. This fix ensures proper type definitions are available.

### ✅ Bug 2: Missing stdlib.h in hpet.c
**Location:** `bdi_kernel/drivers/timer/hpet.c`

**Problem:** The HPET driver uses `calloc()` without including `<stdlib.h>`.

**Fix:** Added missing include:
```c
#include <stdlib.h>       // For calloc/free
```

**Impact:** Implicit declaration error in C99/C11 builds, causing compilation failure. This fix ensures proper function declarations are available.

## Files Modified
- `bdi_kernel/include/bdi/drivers/tty.h` - Added termios.h and sys/types.h
- `bdi_kernel/drivers/timer/hpet.c` - Added stdlib.h

## Verification
- ✅ All required headers are available in standard C library
- ✅ Headers follow kernel coding standards
- ✅ No other driver files require similar fixes (rtc.c, clocksource.c, ioapic.c checked)

## Additional Notes
**Kernel Allocator Consideration:** The use of standard library `calloc()` in kernel code may need to be replaced with kernel-specific allocators (kmalloc/kzalloc) in future work. This is noted for future refactoring but doesn't affect the immediate compilation fix.

## Testing
These are header-only fixes that resolve compilation errors. The functionality of the drivers remains unchanged from PR #150.

---

**Related:** PR #150 (merged)
**Type:** Bug fix
**Priority:** High (blocks compilation)