### PR TITLE
Fix critical bug: Track topics per-phase to avoid corruption in concurrent sessions

### DIFF
--- a/C/training/curriculum/progress_tracker.c
+++ b/C/training/curriculum/progress_tracker.c
@@ -12,7 +12,7 @@ struct progress_tracker {
     overall_metrics_t overall_metrics;
     bool session_active[PHASE_MAX];  // Track active sessions per phase
     time_t session_start_time[PHASE_MAX];  // Track session start times
-    bool topics_used_in_session[TOPIC_MAX];  // Track which topics used in current session
+    bool topics_used_in_session[PHASE_MAX][TOPIC_MAX];  // Track which topics used per phase
     pthread_mutex_t lock;
 };
 
@@ -34,7 +34,7 @@ progress_tracker_t *progress_tracker_create(const char *process_id) {
         tracker->session_start_time[i] = 0;
     }
     
-    // Initialize topic tracking
+    // Initialize topic tracking (2D array)
     memset(tracker->topics_used_in_session, 0, sizeof(tracker->topics_used_in_session));
     
     return tracker;
@@ -63,8 +63,8 @@ void progress_tracker_start_session(progress_tracker_t *tracker, uint8_t phase) 
     tracker->session_active[phase] = true;
     tracker->session_start_time[phase] = time(NULL);
     
-    // Clear topic tracking for new session
-    memset(tracker->topics_used_in_session, 0, sizeof(tracker->topics_used_in_session));
+    // Clear topic tracking for this phase only (not all phases!)
+    memset(tracker->topics_used_in_session[phase], 0, sizeof(tracker->topics_used_in_session[phase]));
     
     // Update first_attempt timestamp if this is the first session
     if (tracker->phase_metrics[phase].first_attempt == 0) {
@@ -97,9 +97,9 @@ void progress_tracker_end_session(progress_tracker_t *tracker, uint8_t phase) {
     time_t session_duration = session_end - tracker->session_start_time[phase];
     tracker->phase_metrics[phase].time_spent += session_duration;
     
-    // **NEW: Update topic times for all topics used in this session**
+    // **FIXED: Update topic times for topics used in THIS PHASE only**
     for (int topic = 0; topic < TOPIC_MAX; topic++) {
-        if (tracker->topics_used_in_session[topic]) {
+        if (tracker->topics_used_in_session[phase][topic]) {
             tracker->topic_metrics[topic].time_spent += session_duration;
         }
     }
@@ -107,8 +107,8 @@ void progress_tracker_end_session(progress_tracker_t *tracker, uint8_t phase) {
     // **NEW: Update overall time**
     tracker->overall_metrics.total_time += session_duration;
     
-    // **NEW: Clear topic tracking for next session**
-    memset(tracker->topics_used_in_session, 0, sizeof(tracker->topics_used_in_session));
+    // **FIXED: Clear topic tracking for this phase only**
+    memset(tracker->topics_used_in_session[phase], 0, sizeof(tracker->topics_used_in_session[phase]));
     
     // Update last_attempt timestamp
     tracker->phase_metrics[phase].last_attempt = session_end;
@@ -158,8 +158,8 @@ void progress_tracker_record_attempt(progress_tracker_t *tracker, curriculum_pha
     }
     tm->accuracy = (double)tm->correct_answers / tm->total_attempts;
     
-    // **NEW: Mark this topic as used in the current session**
-    tracker->topics_used_in_session[topic] = true;
+    // **FIXED: Mark this topic as used in THIS PHASE's session**
+    tracker->topics_used_in_session[phase][topic] = true;
     
     // Update overall metrics (attempts and accuracy only, NOT time)
     overall_metrics_t *om = &tracker->overall_metrics;

--- a/C/training/tests/test_curriculum.c
+++ b/C/training/tests/test_curriculum.c
@@ -415,6 +415,90 @@ void test_time_metrics_consistency() {
     printf("✓ Time metrics consistency test passed\n");
 }
 
+void test_concurrent_sessions() {
+    printf("Testing concurrent sessions with separate topic tracking...\n");
+    
+    progress_tracker_t *tracker = progress_tracker_create("test_concurrent");
+    assert(tracker != NULL);
+    
+    // Start Phase 0 session
+    progress_tracker_start_session(tracker, PHASE_0_FOUNDATIONS);
+    time_t phase0_start = time(NULL);
+    
+    // Record attempts for Phase 0 with TOPIC_MATH
+    for (int i = 0; i < 50; i++) {
+        progress_tracker_record_attempt(tracker, PHASE_0_FOUNDATIONS, TOPIC_MATH, true);
+    }
+    
+    // Sleep 2 seconds
+    sleep(2);
+    
+    // Start Phase 1 session (Phase 0 still active!)
+    progress_tracker_start_session(tracker, PHASE_1_ELEMENTARY);
+    time_t phase1_start = time(NULL);
+    
+    // Record attempts for Phase 1 with TOPIC_LOGIC
+    for (int i = 0; i < 30; i++) {
+        progress_tracker_record_attempt(tracker, PHASE_1_ELEMENTARY, TOPIC_LOGIC, true);
+    }
+    
+    // Sleep 1 second
+    sleep(1);
+    
+    // End Phase 0 session (duration ~3 seconds)
+    progress_tracker_end_session(tracker, PHASE_0_FOUNDATIONS);
+    time_t phase0_end = time(NULL);
+    time_t phase0_duration = phase0_end - phase0_start;
+    
+    // Get metrics after Phase 0 ends
+    topic_metrics_t math_after_p0;
+    topic_metrics_t logic_after_p0;
+    progress_tracker_get_topic_metrics(tracker, TOPIC_MATH, &math_after_p0);
+    progress_tracker_get_topic_metrics(tracker, TOPIC_LOGIC, &logic_after_p0);
+    
+    printf("  Phase 0 duration: %ld seconds\n", phase0_duration);
+    printf("  TOPIC_MATH time after Phase 0: %ld seconds\n", math_after_p0.time_spent);
+    printf("  TOPIC_LOGIC time after Phase 0: %ld seconds\n", logic_after_p0.time_spent);
+    
+    // CRITICAL: Verify Phase 0 duration applied to TOPIC_MATH only (not TOPIC_LOGIC)
+    assert(labs((long)(math_after_p0.time_spent - phase0_duration)) <= 1);
+    assert(logic_after_p0.time_spent == 0);  // Phase 1 not ended yet - this is the key test!
+    
+    // Sleep 1 second
+    sleep(1);
+    
+    // End Phase 1 session (duration ~2 seconds)
+    progress_tracker_end_session(tracker, PHASE_1_ELEMENTARY);
+    time_t phase1_end = time(NULL);
+    time_t phase1_duration = phase1_end - phase1_start;
+    
+    // Get final metrics
+    topic_metrics_t math_final;
+    topic_metrics_t logic_final;
+    progress_tracker_get_topic_metrics(tracker, TOPIC_MATH, &math_final);
+    progress_tracker_get_topic_metrics(tracker, TOPIC_LOGIC, &logic_final);
+    
+    printf("  Phase 1 duration: %ld seconds\n", phase1_duration);
+    printf("  TOPIC_MATH final time: %ld seconds\n", math_final.time_spent);
+    printf("  TOPIC_LOGIC final time: %ld seconds\n", logic_final.time_spent);
+    
+    // CRITICAL: Verify Phase 1 duration applied to TOPIC_LOGIC only (not TOPIC_MATH)
+    assert(labs((long)(math_final.time_spent - phase0_duration)) <= 1);  // Unchanged from Phase 0
+    assert(labs((long)(logic_final.time_spent - phase1_duration)) <= 1);
+    
+    // CRITICAL: Verify topics have different times (proving no cross-contamination)
+    // Phase 0 was ~3 seconds, Phase 1 was ~2 seconds, so they should differ
+    assert(labs((long)(math_final.time_spent - logic_final.time_spent)) >= 1);
+    
+    printf("  ✓ Topics tracked independently per phase\n");
+    printf("  ✓ No cross-contamination between concurrent sessions\n");
+    printf("  ✓ TOPIC_MATH has Phase 0 duration only (%ld seconds)\n", math_final.time_spent);
+    printf("  ✓ TOPIC_LOGIC has Phase 1 duration only (%ld seconds)\n", logic_final.time_spent);
+    
+    progress_tracker_destroy(tracker);
+    printf("✓ Concurrent sessions test passed\n");
+}
+
 int main() {
     printf("=== Running Curriculum System Tests ===\n\n");
     
@@ -435,6 +519,9 @@ int main() {
     
     printf("\n=== Running Time Metrics Tests ===\n\n");
     test_time_metrics_consistency();
+    
+    printf("\n=== Running Concurrent Session Tests ===\n\n");
+    test_concurrent_sessions();
     
     printf("\n=== All tests passed! ===\n");
     return 0;


### PR DESCRIPTION
## Critical Bug Fix: Per-Phase Topic Tracking

This PR fixes a critical bug in the progress tracking system that corrupted topic time metrics when multiple phases trained concurrently.

---

## 🐛 Problem

**Bug Location:** `C/training/curriculum/progress_tracker.c` - `progress_tracker_start_session`

**Issue:**
- `topics_used_in_session` was a **global 1D array** shared across all phases
- `session_active` is **per-phase** (supports concurrent sessions)
- Starting a new session executed `memset(tracker->topics_used_in_session, 0, ...)` which **cleared ALL topics**, including those from other active sessions

**Impact:**
```
Timeline with OLD code (BROKEN):

t=0: Start Phase 0 → Clear all topics
t=1: Record Phase 0 attempts → Mark TOPIC_MATH
t=2: Start Phase 1 → Clear all topics (❌ ERASES Phase 0 topics!)
t=3: Record Phase 1 attempts → Mark TOPIC_LOGIC
t=4: End Phase 0 → Apply duration to topics marked
     ❌ TOPIC_MATH is false (was cleared!)
     ✅ TOPIC_LOGIC is true (from Phase 1)
     ❌ Phase 0 duration applied to TOPIC_LOGIC (WRONG!)
     ❌ Phase 0 duration NOT applied to TOPIC_MATH (WRONG!)
```

**Consequences:**
- ❌ Topic time metrics corrupted when sessions overlap
- ❌ Phase A duration applied to Phase B topics (wrong!)
- ❌ Phase A topics don't get their duration (wrong!)
- ❌ Overall time metrics incorrect
- ❌ Multi-phase training broken

---

## 🔍 Root Cause

**Design Mismatch:**
- Session tracking: **Per-phase** (`session_active[PHASE_MAX]`) - supports concurrent sessions
- Topic tracking: **Global** (`topics_used_in_session[TOPIC_MAX]`) - does NOT support concurrent sessions

This created a race condition where starting a new session cleared topics from other active sessions.

---

## ✅ Solution

**Changed topic tracking from 1D to 2D array:**

```c
// OLD (BROKEN):
bool topics_used_in_session[TOPIC_MAX];  // Global - causes corruption

// NEW (FIXED):
bool topics_used_in_session[PHASE_MAX][TOPIC_MAX];  // Per-phase - correct
```

**Updated all functions:**

1. **`progress_tracker_start_session`** - Clear only specific phase's topics:
```c
// OLD: memset(tracker->topics_used_in_session, 0, sizeof(...));
// NEW: memset(tracker->topics_used_in_session[phase], 0, sizeof(...));
```

2. **`progress_tracker_record_attempt`** - Mark topic for specific phase:
```c
// OLD: tracker->topics_used_in_session[topic] = true;
// NEW: tracker->topics_used_in_session[phase][topic] = true;
```

3. **`progress_tracker_end_session`** - Use topics for specific phase:
```c
// OLD: if (tracker->topics_used_in_session[topic])
// NEW: if (tracker->topics_used_in_session[phase][topic])
```

---

## 🧪 Testing

**Added comprehensive `test_concurrent_sessions()` test:**

```
Timeline with NEW code (FIXED):

t=0: Start Phase 0 → Clear Phase 0 topics only
t=1: Record Phase 0 attempts → Mark Phase 0 TOPIC_MATH
t=2: Start Phase 1 → Clear Phase 1 topics only (✅ Phase 0 topics preserved!)
t=3: Record Phase 1 attempts → Mark Phase 1 TOPIC_LOGIC
t=4: End Phase 0 → Apply duration to Phase 0 topics
     ✅ Phase 0 TOPIC_MATH is true
     ✅ Phase 1 TOPIC_LOGIC is false (different phase)
     ✅ Phase 0 duration applied to TOPIC_MATH (CORRECT!)
     ✅ Phase 0 duration NOT applied to TOPIC_LOGIC (CORRECT!)
t=5: End Phase 1 → Apply duration to Phase 1 topics
     ✅ Phase 1 TOPIC_LOGIC is true
     ✅ Phase 0 TOPIC_MATH is false (different phase)
     ✅ Phase 1 duration applied to TOPIC_LOGIC (CORRECT!)
     ✅ Phase 1 duration NOT applied to TOPIC_MATH (CORRECT!)
```

**Test Results:**
```
Testing concurrent sessions with separate topic tracking...
  Phase 0 duration: 3 seconds
  TOPIC_MATH time after Phase 0: 3 seconds
  TOPIC_LOGIC time after Phase 0: 0 seconds
  Phase 1 duration: 2 seconds
  TOPIC_MATH final time: 3 seconds
  TOPIC_LOGIC final time: 2 seconds
  ✓ Topics tracked independently per phase
  ✓ No cross-contamination between concurrent sessions
  ✓ TOPIC_MATH has Phase 0 duration only (3 seconds)
  ✓ TOPIC_LOGIC has Phase 1 duration only (2 seconds)
✓ Concurrent sessions test passed
```

**All tests passing:**
- ✅ All existing tests still pass
- ✅ New concurrent session test passes
- ✅ No memory leaks
- ✅ No undefined behavior

---

## 📊 Impact

**Before Fix:**
- ❌ Concurrent sessions corrupt topic tracking
- ❌ Topic time metrics unreliable
- ❌ Multi-phase training broken

**After Fix:**
- ✅ Concurrent sessions work correctly
- ✅ Topic time metrics accurate
- ✅ No corruption when multiple phases train simultaneously
- ✅ Multi-phase training reliable

---

## 🎯 Why This Matters

This fix is **critical** for AI processes that train on multiple phases concurrently. Without it:
- Training metrics are corrupted
- Progress tracking is unreliable
- Multi-phase curriculum learning doesn't work correctly

With this fix:
- Each phase tracks its own topics independently
- Concurrent sessions don't interfere with each other
- Topic time metrics are accurate and reliable
- The system is production-ready for multi-phase training

---

## 📝 Changes

**Files Modified:**
1. `C/training/curriculum/progress_tracker.c` - Per-phase topic tracking implementation
2. `C/training/tests/test_curriculum.c` - Added concurrent session test

**Lines Changed:**
- +97 insertions
- -10 deletions

**Memory Impact:**
- Minimal: 8 phases × ~20 topics = 160 bytes additional memory
- Well worth it for correct concurrent session support

---

## ✅ Checklist

- [x] Bug identified and root cause analyzed
- [x] Fix implemented with per-phase topic tracking
- [x] Comprehensive test added for concurrent sessions
- [x] All existing tests still pass
- [x] No memory leaks or undefined behavior
- [x] Code builds cleanly
- [x] Documentation updated in commit message

---

## 🔗 Related

- Fixes the design mismatch between per-phase sessions and global topic tracking
- Completes Phase 2 implementation with reliable concurrent session support
- Enables production-ready multi-phase training for AI processes

This PR should be merged to ensure the training system works correctly with concurrent sessions.